### PR TITLE
Replace Core with Base for better performances

### DIFF
--- a/dune
+++ b/dune
@@ -9,5 +9,5 @@
  (public_name feather)
  (inline_tests)
  (modules feather)
- (libraries core stdio threads spawn)
+ (libraries base stdio threads spawn)
  (preprocess (pps ppx_expect)))

--- a/feather.ml
+++ b/feather.ml
@@ -411,10 +411,10 @@ hi
 
     let%expect_test "redirection" =
       find "." ~ignore_hidden:true ~kind:`Files ~name:"*.ml"
-      |. rg_v {|\.pp\.|} |> print;
+      |. rg_v {|\.pp\.|} |. sort |> print;
       [%expect {|
-        ./feather.ml
-        ./example.ml |}]
+        ./example.ml
+        ./feather.ml |}]
 
     let%expect_test "redirection" =
       (* TODO: tests for redirection *)

--- a/feather.mli
+++ b/feather.mli
@@ -1,4 +1,4 @@
-open Core
+open Base
 
 type cmd
 


### PR DESCRIPTION
I use Feather in an interpreted context (which is pretty appropriate for drop-in bash script replacements). Hence in my use case each time the script is launched, every dependency of Feather has to be dynamically loaded.
Core is better than Base regarding the number of features, but it is also way heavier to load and thus has a big impact on script loading time. On a small example :
```ocaml
#!/usr/bin/env -S opam exec --switch scripting -- ocaml
#use "topfind"
#thread
#require "feather"

open Feather

let main =
  echo "bonjour" |> run
```

Before (with Core) :
```
Benchmark #1: ./feather_base.ml
  Time (mean ± σ):      1.205 s ±  0.017 s    [User: 1.069 s, System: 0.122 s]
  Range (min … max):    1.181 s …  1.233 s    10 runs
```
After (with Base) :
```
Benchmark #1: ./feather_base.ml
  Time (mean ± σ):     612.8 ms ±   9.9 ms    [User: 534.1 ms, System: 69.7 ms]
  Range (min … max):   601.8 ms … 627.0 ms    10 runs
```
With a 5 runs warmup.

it should be identical (and the tests run correctly) except for the debugging format.

Edit : Added a sort command in test since the order of find seems to be dependent on your filesystem

I did not touch the file example.ml.
While I didn't do it to keep the diff legible, I suggest to automatically reindent all the file.