### PR TITLE
Add support to &&, || and ; bash operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ val write_stderr_to : string -> cmd -> cmd
 val append_stderr_to : string -> cmd -> cmd
 ```
 
-or with infix operators in `Feather.File_redirection_infix`
+or with infix operators in `Feather.Infix`
 
 ``` ocaml
 (* Stdout *)
@@ -86,7 +86,7 @@ This does what you would expect:
 
 ``` ocaml
 open Feather
-open Feather.File_redirection_infix
+open Feather.Infix
 
 echo "hi"  > "/tmp/out"
 ```
@@ -199,7 +199,7 @@ style over a monadic one. In Shexp you incrementally construct a
 hand, a `Feather.cmd` is not parametrized: you run it to get a string
 which can be parsed directly by OCaml later. No monads in sight!
 
-As a comparison, say you wanted to count the number of characeters from
+As a comparison, say you wanted to count the number of characters from
 "ls" using Shexp:
 
 ``` ocaml

--- a/example.ml
+++ b/example.ml
@@ -1,7 +1,7 @@
 open! Base
 open! Stdio
 open Feather
-open Feather.File_redirection_infix
+open Feather.Infix
 
 let __ () =
   cat "dune" |. rg "feather" |> stdout_to_stderr |. echo "hi" |. sort

--- a/feather.ml
+++ b/feather.ml
@@ -93,31 +93,31 @@ let ( |. ) a b =
   fun ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env ->
     a ~stdin_reader ~stdout_writer:pipe_writer
       ~stderr_writer:(Unix.dup stderr_writer) ~background:true ~cwd ~env;
-    b ~stdin_reader:pipe_reader ~stdout_writer
-      ~stderr_writer ~background ~cwd ~env
+    b ~stdin_reader:pipe_reader ~stdout_writer ~stderr_writer ~background ~cwd
+      ~env
 
-let ( &&. ) a b =
-  fun ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env ->
+let ( &&. ) a b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd
+    ~env =
   a ~stdin_reader ~stdout_writer:(Unix.dup stdout_writer)
     ~stderr_writer:(Unix.dup stderr_writer) ~background ~cwd ~env;
   match !State.exit with
   | 0 -> b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env
   | _ ->
-    Unix.close stdout_writer;
-    Unix.close stderr_writer
+      Unix.close stdout_writer;
+      Unix.close stderr_writer
 
-let ( ||. ) a b =
-  fun ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env ->
+let ( ||. ) a b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd
+    ~env =
   a ~stdin_reader ~stdout_writer:(Unix.dup stdout_writer)
     ~stderr_writer:(Unix.dup stderr_writer) ~background ~cwd ~env;
   match !State.exit with
   | 0 ->
-    Unix.close stdout_writer;
-    Unix.close stderr_writer
+      Unix.close stdout_writer;
+      Unix.close stderr_writer
   | _ -> b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env
 
-let ( ->. ) a b =
-  fun ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env ->
+let ( ->. ) a b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd
+    ~env =
   a ~stdin_reader ~stdout_writer:(Unix.dup stdout_writer)
     ~stderr_writer:(Unix.dup stderr_writer) ~background ~cwd ~env;
   b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env
@@ -425,12 +425,15 @@ hi
     let%expect_test _ =
       echo "test" |. (process "false" [] &&. cat "-") |> print;
       [%expect ""]
+
     let%expect_test _ =
       echo "test" |. (process "true" [] &&. cat "-") |> print;
       [%expect "test"]
+
     let%expect_test _ =
       echo "test" |. (process "false" [] ||. cat "-") |> print;
       [%expect "test"]
+
     let%expect_test _ =
       echo "test" |. (process "true" [] ||. cat "-") |> print;
       [%expect ""]

--- a/feather.ml
+++ b/feather.ml
@@ -337,9 +337,9 @@ module Infix = struct
 
   let ( < ) cmd str = read_stdin_from str cmd
 
-  let ( && ) = and_
+  let ( &&. ) = and_
 
-  let ( || ) = or_
+  let ( ||. ) = or_
 
   let ( ->. ) = sequence
 end
@@ -431,20 +431,36 @@ hi
         b--1 |}]
 
     let%expect_test _ =
-      echo "test" |. (process "false" [] && cat "-") |> print;
+      process "false" [] &&. echo "test" |> print;
       [%expect ""]
 
     let%expect_test _ =
-      echo "test" |. (process "true" [] && cat "-") |> print;
+      process "true" [] &&. echo "test" |> print;
       [%expect "test"]
 
     let%expect_test _ =
-      echo "test" |. (process "false" [] || cat "-") |> print;
+      process "false" [] ||. echo "test" |> print;
       [%expect "test"]
 
     let%expect_test _ =
-      echo "test" |. (process "true" [] || cat "-") |> print;
+      process "true" [] ||. echo "test" |> print;
       [%expect ""]
+
+    let%expect_test _ =
+      process "false" [] ||. process "true" [] &&. echo "test" |> print;
+      [%expect "test"]
+
+    let%expect_test _ =
+      process "true" [] &&. process "false" [] ||. echo "test" |> print;
+      [%expect "test"]
+
+    let%expect_test _ =
+      process "false" [] ||. process "false" [] &&. echo "test" |> print;
+      [%expect ""]
+
+    let%expect_test _ =
+      process "true" [] &&. process "false" [] ||. echo "test" |> print;
+      [%expect "test"]
 
     let%expect_test _ =
       echo "test" |. process "true" [] ->. cat "-" |> print;

--- a/feather.ml
+++ b/feather.ml
@@ -96,8 +96,7 @@ let ( |. ) a b =
     b ~stdin_reader:pipe_reader ~stdout_writer ~stderr_writer ~background ~cwd
       ~env
 
-let ( &&. ) a b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd
-    ~env =
+let and_ a b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env =
   a ~stdin_reader ~stdout_writer:(Unix.dup stdout_writer)
     ~stderr_writer:(Unix.dup stderr_writer) ~background ~cwd ~env;
   match !State.exit with
@@ -106,8 +105,7 @@ let ( &&. ) a b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd
       Unix.close stdout_writer;
       Unix.close stderr_writer
 
-let ( ||. ) a b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd
-    ~env =
+let or_ a b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env =
   a ~stdin_reader ~stdout_writer:(Unix.dup stdout_writer)
     ~stderr_writer:(Unix.dup stderr_writer) ~background ~cwd ~env;
   match !State.exit with
@@ -116,7 +114,7 @@ let ( ||. ) a b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd
       Unix.close stderr_writer
   | _ -> b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env
 
-let ( ->. ) a b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd
+let sequence a b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd
     ~env =
   a ~stdin_reader ~stdout_writer:(Unix.dup stdout_writer)
     ~stderr_writer:(Unix.dup stderr_writer) ~background ~cwd ~env;
@@ -326,7 +324,7 @@ let read_stdin_from str cmd ~stdin_reader:_ ~stdout_writer ~stderr_writer
   let stdin_reader = Unix.openfile str [ O_RDONLY ] 0 in
   cmd ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env
 
-module File_redirection_infix = struct
+module Infix = struct
   let ( > ) cmd str = write_stdout_to str cmd
 
   let ( >> ) cmd str = append_stdout_to str cmd
@@ -336,6 +334,12 @@ module File_redirection_infix = struct
   let ( >>! ) cmd str = append_stderr_to str cmd
 
   let ( < ) cmd str = read_stdin_from str cmd
+
+  let ( && ) = and_
+
+  let ( || ) = or_
+
+  let ( ->. ) = sequence
 end
 
 let stdout_to_stderr cmd ~stdin_reader ~stdout_writer ~stderr_writer ~background
@@ -372,6 +376,8 @@ let () = Caml.at_exit terminate_child_processes
 
 let%test_module _ =
   (module struct
+    open Infix
+
     let print cmd = collect_lines cmd |> List.iter ~f:print_endline
 
     let%expect_test _ =
@@ -423,20 +429,28 @@ hi
         b--1 |}]
 
     let%expect_test _ =
-      echo "test" |. (process "false" [] &&. cat "-") |> print;
+      echo "test" |. (process "false" [] && cat "-") |> print;
       [%expect ""]
 
     let%expect_test _ =
-      echo "test" |. (process "true" [] &&. cat "-") |> print;
+      echo "test" |. (process "true" [] && cat "-") |> print;
       [%expect "test"]
 
     let%expect_test _ =
-      echo "test" |. (process "false" [] ||. cat "-") |> print;
+      echo "test" |. (process "false" [] || cat "-") |> print;
       [%expect "test"]
 
     let%expect_test _ =
-      echo "test" |. (process "true" [] ||. cat "-") |> print;
+      echo "test" |. (process "true" [] || cat "-") |> print;
       [%expect ""]
+
+    let%expect_test _ =
+      echo "test" |. process "true" [] ->. cat "-" |> print;
+      [%expect "test"]
+
+    let%expect_test _ =
+      echo "test" |. process "false" [] ->. cat "-" |> print;
+      [%expect "test"]
 
     let%expect_test "redirection" =
       find "." ~ignore_hidden:true ~kind:`Files ~name:"*.ml"

--- a/feather.ml
+++ b/feather.ml
@@ -96,6 +96,32 @@ let ( |. ) a b =
     b ~stdin_reader:pipe_reader ~stdout_writer
       ~stderr_writer ~background ~cwd ~env
 
+let ( &&. ) a b =
+  fun ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env ->
+  a ~stdin_reader ~stdout_writer:(Unix.dup stdout_writer)
+    ~stderr_writer:(Unix.dup stderr_writer) ~background ~cwd ~env;
+  match !State.exit with
+  | 0 -> b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env
+  | _ ->
+    Unix.close stdout_writer;
+    Unix.close stderr_writer
+
+let ( ||. ) a b =
+  fun ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env ->
+  a ~stdin_reader ~stdout_writer:(Unix.dup stdout_writer)
+    ~stderr_writer:(Unix.dup stderr_writer) ~background ~cwd ~env;
+  match !State.exit with
+  | 0 ->
+    Unix.close stdout_writer;
+    Unix.close stderr_writer
+  | _ -> b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env
+
+let ( ->. ) a b =
+  fun ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env ->
+  a ~stdin_reader ~stdout_writer:(Unix.dup stdout_writer)
+    ~stderr_writer:(Unix.dup stderr_writer) ~background ~cwd ~env;
+  b ~stdin_reader ~stdout_writer ~stderr_writer ~background ~cwd ~env
+
 let collect_gen ?cwd ?env cmd =
   let stdout_reader, stdout_writer = Unix.pipe () in
   cmd ~stdin_reader:(Unix.dup Unix.stdin) ~stdout_writer

--- a/feather.ml
+++ b/feather.ml
@@ -422,6 +422,19 @@ hi
         a--0
         b--1 |}]
 
+    let%expect_test _ =
+      echo "test" |. (process "false" [] &&. cat "-") |> print;
+      [%expect ""]
+    let%expect_test _ =
+      echo "test" |. (process "true" [] &&. cat "-") |> print;
+      [%expect "test"]
+    let%expect_test _ =
+      echo "test" |. (process "false" [] ||. cat "-") |> print;
+      [%expect "test"]
+    let%expect_test _ =
+      echo "test" |. (process "true" [] ||. cat "-") |> print;
+      [%expect ""]
+
     let%expect_test "redirection" =
       find "." ~ignore_hidden:true ~kind:`Files ~name:"*.ml"
       |. rg_v {|\.pp\.|} |. sort |> print;

--- a/feather.mli
+++ b/feather.mli
@@ -135,10 +135,10 @@ module Infix : sig
   val ( < ) : cmd -> string -> cmd
 
   (** Same as [and_] *)
-  val (&&) : cmd -> cmd -> cmd
+  val (&&.) : cmd -> cmd -> cmd
 
   (** Same as [or_] *)
-  val (||) : cmd -> cmd -> cmd
+  val (||.) : cmd -> cmd -> cmd
 
   (** Same as [sequence] *)
   val (->.) : cmd -> cmd -> cmd

--- a/feather.mli
+++ b/feather.mli
@@ -82,14 +82,14 @@ val cut' : ?complement:unit -> ?d:char -> int list -> cmd
 val ( |. ) : cmd -> cmd -> cmd
 (** [ |. ] is feather's version of a "|" in bash. *)
 
-val ( &&. ) : cmd -> cmd -> cmd
-(** [ &&. ] is feather's version of a "&&" in bash. *)
+val and_ : cmd -> cmd -> cmd
+(** [ and_ ] is feather's version of a "&&" in bash. See Infix module for more. *)
 
-val ( ||. ) : cmd -> cmd -> cmd
-(** [ ||. ] is feather's version of a "||" in bash. *)
+val  or_ : cmd -> cmd -> cmd
+(** [ or_ ] is feather's version of a "||" in bash. See Infix module for more. *)
 
-val ( ->. ) : cmd -> cmd -> cmd
-(** [ ->. ] is feather's version of a ";" in bash. *)
+val sequence : cmd -> cmd -> cmd
+(** [ sequence ] is feather's version of a ";" in bash. See Infix module for more. *)
 
 val collect_lines :
   ?cwd:string -> ?env:(string * string) list -> cmd -> string list
@@ -117,18 +117,31 @@ val write_stderr_to : string -> cmd -> cmd
 
 val append_stderr_to : string -> cmd -> cmd
 
-module File_redirection_infix : sig
-  (* Stdout *)
+val read_stdin_from : string -> cmd -> cmd
+
+module Infix : sig
+
+  (** Redirect Stdout *)
   val ( > ) : cmd -> string -> cmd
 
   val ( >> ) : cmd -> string -> cmd
 
-  (* Stderr *)
+  (** Redirect Stderr *)
   val ( >! ) : cmd -> string -> cmd
 
   val ( >>! ) : cmd -> string -> cmd
 
+  (** Read file from stdin *)
   val ( < ) : cmd -> string -> cmd
+
+  (** Same as [and_] *)
+  val (&&) : cmd -> cmd -> cmd
+
+  (** Same as [or_] *)
+  val (||) : cmd -> cmd -> cmd
+
+  (** Same as [sequence] *)
+  val (->.) : cmd -> cmd -> cmd
 end
 
 val stdout_to_stderr : cmd -> cmd

--- a/feather.mli
+++ b/feather.mli
@@ -82,6 +82,15 @@ val cut' : ?complement:unit -> ?d:char -> int list -> cmd
 val ( |. ) : cmd -> cmd -> cmd
 (** [ |. ] is feather's version of a "|" in bash. *)
 
+val ( &&. ) : cmd -> cmd -> cmd
+(** [ &&. ] is feather's version of a "&&" in bash. *)
+
+val ( ||. ) : cmd -> cmd -> cmd
+(** [ ||. ] is feather's version of a "||" in bash. *)
+
+val ( ->. ) : cmd -> cmd -> cmd
+(** [ ->. ] is feather's version of a ";" in bash. *)
+
 val collect_lines :
   ?cwd:string -> ?env:(string * string) list -> cmd -> string list
 


### PR DESCRIPTION
This PR add the support to 3 new operators : 
- `&&` : `A &&. B` , lazy AND opperator, run B only if A exit with 0
- `||` : `A ||. B`, lazy OR operator, run B only if A do not exit with 0
- `;` : `A ->. B` sequence operator, run A, then run B regardless of A exit status

With small tests for `&&.` and `||.`.

Beware, the relative precedence of these operators is not the same as in Bash. You might need to use parenthesis instead.