### PR TITLE
Add retry loop when EINTR encountered

### DIFF
--- a/feather.ml
+++ b/feather.ml
@@ -5,9 +5,24 @@ module Sys = Caml.Sys
 module Unix = struct
   include Unix
 
+  let rec try_until_no_eintr f =
+    try f () with Unix.Unix_error (Unix.EINTR, _, _) -> try_until_no_eintr f
+
+  let with_restart_on_eintr ?(restart = false) f =
+    if restart then try_until_no_eintr f else f ()
+
   let dup = dup ~cloexec:true
 
   let pipe = pipe ~cloexec:true
+
+  let read ?restart fd buf pos len =
+    with_restart_on_eintr ?restart (fun () -> read fd buf pos len)
+
+  let write ?restart fd buf pos len =
+    with_restart_on_eintr ?restart (fun () -> write fd buf pos len)
+
+  let waitpid ?(restart = true) wait_flags pid =
+    with_restart_on_eintr ~restart (fun () -> waitpid wait_flags pid)
 end
 
 module Thread = struct
@@ -370,7 +385,13 @@ let fzf ?cwd ?env cmd =
 let terminate_child_processes () =
   process "pgrep" [ "-P"; Int.to_string State.pid ]
   |> collect_lines |> List.map ~f:Int.of_string
-  |> List.iter ~f:(fun pid -> ignore (Unix.kill Sys.sigterm pid))
+  |> List.iter ~f:(fun pid ->
+         try Unix.kill Sys.sigterm pid
+         with Unix.Unix_error (Unix.ESRCH, _, _) ->
+           (* [Unix.ERSCH] is raised when a process cannot be found, which
+            * means that the child has already terminated, so it should
+            * be safe to ignore this exception. *)
+           ())
 
 let () = Caml.at_exit terminate_child_processes
 
@@ -480,4 +501,10 @@ hi
     let%expect_test "redirection" =
       (* TODO: tests for redirection *)
       ()
+
+    let%expect_test "waitpid should retry on EINTR" =
+      process "kill"
+        (List.map ~f:Int.to_string [ Caml.Sys.sigurg; Unix.getpid () ])
+      |> print;
+      [%expect ""]
   end)


### PR DESCRIPTION
Fixes #7 

Added a wrapper around interruptible system calls to retry on failure if error is `EINTR`.

This change follows the use of a [retry](https://github.com/janestreet/core/blob/de2aea339e4b0ccaea30c78455e6641993234f01/src/core_unix.ml#L26) helper in Core_unix - do we need to attribute this change to them?

I've also added the restart option to read and write, as per the implementation in [Core_unix](https://github.com/janestreet/core/blob/de2aea339e4b0ccaea30c78455e6641993234f01/src/core_unix.ml#L1080).