### PR TITLE
New collection, status propagation and background system

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,32 @@ the output. To run a command without capturing any output, simply use
 val run : ?cwd:string -> ?env:(string * string) list -> cmd -> unit
 ```
 
-But if you want to use the process's stdout in OCaml,
-`Feather.collect_stdout` or `Feather.collect_lines` will be your friend:
+This will block until the command finishes executing. You can also run a command
+in the background with `Feather.run_bg`. It will be killed if it has not
+finished executing when the parent program terminates.
+
+But if you want to use the process's stdout, stderr or status in OCaml, 
+`Feather.collect` will be your friend:
 
 ``` ocaml
-val collect_stdout : ?cwd:string -> ?env:(string * string) list -> cmd -> string
+val collect : ?cwd:string -> ?env:(string * string) list -> 'a what_to_collect -> cmd -> 'a
+```
 
-val collect_lines : ?cwd:string -> ?env:(string * string) list -> cmd -> string list
+The parameter of type `what_to_collect` can be `status`, `stdout`,
+`stderr`, `stdout_and_stderr`, `stdout_and_status`, `stderr_and_status` or
+`everything`, depending on what should be collected.
+
+```ocaml
+let stderr, status = command_1 |> collect stderr_and_status in
+(* Feather.lines can be used to transform a long string into a list of its lines *)
+let stdout_lines = command_2 |> collect stdout |> lines in ...
 ```
 
 Perhaps the most important feature of Feather is that it lets you use
 OCaml within a chain of pipes:
 
 ``` ocaml
-utop# process "ps" [] |. map_lines String.uppercase |. grep "BASH" |> collect_stdout;;
+utop# process "ps" [] |. map_lines String.uppercase |. grep "BASH" |> collect stdout;;
 - : string = " 232699 PTS/4    00:00:00 BASH"
 ```
 
@@ -59,13 +71,19 @@ Feather also provides a bunch of wrappers around common unix commands
 like `grep`, `find`, `sort`, etc. See
 [feather.mli](./browse/feather.mli) for the full list.
 
-Lastly, Feather has support for file descriptor redirection. Either with
-functions like
+Lastly, Feather has support for file descriptor redirection, and common 
+shell chaining operators. Either with functions like
 
 ``` ocaml
 val write_stderr_to : string -> cmd -> cmd
 
 val append_stderr_to : string -> cmd -> cmd
+
+val and_ : cmd -> cmd -> cmd
+
+val or_ : cmd -> cmd -> cmd
+
+val sequence : cmd -> cmd -> cmd
 ```
 
 or with infix operators in `Feather.Infix`
@@ -80,6 +98,15 @@ val ( >> ) : cmd -> string -> cmd
 val ( >! ) : cmd -> string -> cmd
 
 val ( >>! ) : cmd -> string -> cmd
+
+(* Executes second command if first is successful *)
+val ( &&. ) : cmd -> cmd -> cmd
+
+(* Executes second command if first fails *)
+val ( ||. ) : cmd -> cmd -> cmd
+
+(* Executes second command no matter what *)
+val ( ->. ) : cmd -> cmd -> cmd
 ```
 
 This does what you would expect:
@@ -101,7 +128,7 @@ Say you wanted to make a quick sentence generator:
 for i = 0 to 3 do
   let output = "/tmp/output" ^ Int.to_string i in
   cat "/usr/share/dict/words" |. shuf |. head 5 > output |> run;
-  match tr "a-z" "A-Z" < output |> collect_lines with
+  match tr "a-z" "A-Z" < output |> collect stdout |> lines with
   | [ a; b; c; d; e ] ->
       (printf "You are a %s %s and I think this is the %s %s of all %s.\n")
         a b c d e
@@ -230,7 +257,7 @@ let () =
 
 ``` ocaml
 let length =
-  Feather.process "ls" [] |> Feather.collect_stdout |> String.length
+  Feather.process "ls" [] |> Feather.collect stdout |> String.length
 in
 print_int length
 ```

--- a/example.ml
+++ b/example.ml
@@ -47,7 +47,8 @@ let () =
 
 let __ () =
   let stderr, status =
-    ls "thisfiledoesnotexists" |> collect stderr_and_status in
+    ls "thisfiledoesnotexists" |> collect stderr_and_status
+  in
   printf "ls returned error code %d: %s\n" status stderr
 
-(* let () = ls "." |> run ~cwd:"_build" *)
+let __ () = ls "." |> run ~cwd:"_build"

--- a/example.ml
+++ b/example.ml
@@ -18,7 +18,7 @@ let __ () =
   for i = 0 to 3 do
     let output = "/tmp/output" ^ Int.to_string i in
     cat "/usr/share/dict/words" |. shuf |. head 5 > output |> run;
-    match tr "a-z" "A-Z" < output |> collect_lines with
+    match tr "a-z" "A-Z" < output |> collect stdout |> lines with
     | [ a; b; c; d; e ] ->
         (printf "You are a %s %s and I think this is the %s %s of all %s.\n")
           a b c d e
@@ -44,5 +44,10 @@ let () =
   |. process "sort" [ "-n" ]
   |. process "uniq" [ "-c" ]
   |> run
+
+let __ () =
+  let stderr, status =
+    ls "thisfiledoesnotexists" |> collect stderr_and_status in
+  printf "ls returned error code %d: %s\n" status stderr
 
 (* let () = ls "." |> run ~cwd:"_build" *)

--- a/feather.ml
+++ b/feather.ml
@@ -635,22 +635,29 @@ hi
       [%expect ""]
 
     let%expect_test "redirection/collection" =
-      let print_status (stdout, stderr) =
-        printf "Stdout:%s\nStderr:%s\n" stdout stderr
+      let print cmd =
+        let stdout, stderr = cmd |> collect stdout_and_stderr in
+        printf "== Stdout ==\n%s\n== Stderr ==\n%s\n" stdout stderr
       in
-      echo "test" |> collect stdout_and_stderr |> print_status;
-      echo "test1" |> stdout_to_stderr &&. echo "test2"
-      |> collect stdout_and_stderr |> print_status;
-      echo "test1" |> stdout_to_stderr &&. echo "test2" |> stderr_to_stdout
-      |> collect stdout_and_stderr |> print_status;
+      echo "test" |> print;
+      [%expect {|
+        == Stdout ==
+        test
+        == Stderr == |}];
+      echo "test1" |> stdout_to_stderr &&. echo "test2" |> print;
       [%expect
         {|
-        Stdout:test
-        Stderr:
-        Stdout:test2
-        Stderr:test1
-        Stdout:test1
+        == Stdout ==
         test2
-        Stderr:
+        == Stderr ==
+        test1 |}];
+      echo "test1" |> stdout_to_stderr &&. echo "test2" |> stderr_to_stdout
+      |> print;
+      [%expect
+        {|
+        == Stdout ==
+        test1
+        test2
+        == Stderr ==
         |}]
   end)

--- a/feather.ml
+++ b/feather.ml
@@ -67,6 +67,7 @@ type cmd =
   | FilterMap of (string -> string option)
 
 (* GADT type to accomplish dynamic return types for collect *)
+type everything = { stdout : string ; stderr : string ; status : int }
 type _ what_to_collect =
   | Collect_status : int what_to_collect
   | Collect_stdout : string what_to_collect
@@ -74,7 +75,7 @@ type _ what_to_collect =
   | Collect_stdout_stderr : (string * string) what_to_collect
   | Collect_stdout_status : (string * int) what_to_collect
   | Collect_stderr_status : (string * int) what_to_collect
-  | Collect_everything : (string * string * int) what_to_collect
+  | Collect_everything : everything what_to_collect
 
 let resolve_in_path prog =
   (* Do not try to resolve in the path if the program is something like
@@ -374,7 +375,7 @@ let collect (type a) ?cwd ?env (what_to_collect : a what_to_collect) cmd : a =
       let status = eval ~stdout_writer ~stderr_writer () in
       let stdout = collect_into_string stdout_reader in
       let stderr = collect_into_string stderr_reader in
-      (stdout, stderr, status)
+      {status; stdout; stderr}
 
 let lines = String.split_lines
 

--- a/feather.ml
+++ b/feather.ml
@@ -641,14 +641,14 @@ hi
       [%expect ""]
 
     let%expect_test "redirection/collection" =
-      let print_stat (stdout, stderr) =
+      let print_status (stdout, stderr) =
         printf "Stdout:%s\nStderr:%s\n" stdout stderr
       in
-      echo "test" |> collect stdout_and_stderr |> print_stat;
+      echo "test" |> collect stdout_and_stderr |> print_status;
       echo "test1" |> stdout_to_stderr &&. echo "test2"
-      |> collect stdout_and_stderr |> print_stat;
+      |> collect stdout_and_stderr |> print_status;
       echo "test1" |> stdout_to_stderr &&. echo "test2" |> stderr_to_stdout
-      |> collect stdout_and_stderr |> print_stat;
+      |> collect stdout_and_stderr |> print_status;
       [%expect
         {|
         Stdout:test

--- a/feather.ml
+++ b/feather.ml
@@ -68,13 +68,13 @@ type cmd =
 
 (* GADT type to accomplish dynamic return types for collect *)
 type _ what_to_collect =
-  | ColStatus : int what_to_collect
-  | ColStdout : string what_to_collect
-  | ColStderr : string what_to_collect
-  | ColStdoutStderr : (string * string) what_to_collect
-  | ColStdoutStatus : (string * int) what_to_collect
-  | ColStderrStatus : (string * int) what_to_collect
-  | ColEverything : (string * string * int) what_to_collect
+  | Col_status : int what_to_collect
+  | Col_stdout : string what_to_collect
+  | Col_stderr : string what_to_collect
+  | Col_stdout_stderr : (string * string) what_to_collect
+  | Col_stdout_status : (string * int) what_to_collect
+  | Col_stderr_status : (string * int) what_to_collect
+  | Col_everything : (string * string * int) what_to_collect
 
 let resolve_in_path prog =
   (* Do not try to resolve in the path if the program is something like
@@ -303,19 +303,19 @@ let stderr_to_stdout cmd = ErrToOut cmd
 
 (* === Collection facilities === *)
 
-let status = ColStatus
+let status = Col_status
 
-let stdout = ColStdout
+let stdout = Col_stdout
 
-let stderr = ColStderr
+let stderr = Col_stderr
 
-let stdout_and_stderr = ColStdoutStderr
+let stdout_and_stderr = Col_stdout_stderr
 
-let stdout_and_status = ColStdoutStatus
+let stdout_and_status = Col_stdout_status
 
-let stderr_and_status = ColStderrStatus
+let stderr_and_status = Col_stderr_status
 
-let everything = ColEverything
+let everything = Col_everything
 
 (* Opens a pipe for selected outputs and returns them optionally
  * after executing the command *)
@@ -342,10 +342,10 @@ let collect_gen ?cwd ?env (sel_stdout, sel_stderr) cmd =
 
 (* Should we collect stdout, stderr ? *)
 let selector_switch : type a. a what_to_collect -> bool * bool = function
-  | ColStatus -> (false, false)
-  | ColStdout | ColStdoutStatus -> (true, false)
-  | ColStderr | ColStderrStatus -> (false, true)
-  | ColStdoutStderr | ColEverything -> (true, true)
+  | Col_status -> (false, false)
+  | Col_stdout | Col_stdout_status -> (true, false)
+  | Col_stderr | Col_stderr_status -> (false, true)
+  | Col_stdout_stderr | Col_everything -> (true, true)
 
 (* Take the collected status and potential stdout/stderr streams, return the
  * expected output of collect *)
@@ -353,13 +353,13 @@ let pack :
     type a. int -> string option * string option -> a what_to_collect -> a =
  fun status (stdout, stderr) collection ->
   match (collection, stdout, stderr) with
-  | ColStatus, _, _ -> status
-  | ColStdout, Some x, _ -> x
-  | ColStdoutStatus, Some x, _ -> (x, status)
-  | ColStderr, _, Some x -> x
-  | ColStderrStatus, _, Some x -> (x, status)
-  | ColStdoutStderr, Some x, Some y -> (x, y)
-  | ColEverything, Some x, Some y -> (x, y, status)
+  | Col_status, _, _ -> status
+  | Col_stdout, Some x, _ -> x
+  | Col_stdout_status, Some x, _ -> (x, status)
+  | Col_stderr, _, Some x -> x
+  | Col_stderr_status, _, Some x -> (x, status)
+  | Col_stdout_stderr, Some x, Some y -> (x, y)
+  | Col_everything, Some x, Some y -> (x, y, status)
   | _ -> failwith "Did not collect the expected outputs"
 
 (* Take an input channel and read everything into a single string *)

--- a/feather.ml
+++ b/feather.ml
@@ -68,13 +68,13 @@ type cmd =
 
 (* GADT type to accomplish dynamic return types for collect *)
 type _ what_to_collect =
-  | Col_status : int what_to_collect
-  | Col_stdout : string what_to_collect
-  | Col_stderr : string what_to_collect
-  | Col_stdout_stderr : (string * string) what_to_collect
-  | Col_stdout_status : (string * int) what_to_collect
-  | Col_stderr_status : (string * int) what_to_collect
-  | Col_everything : (string * string * int) what_to_collect
+  | Collect_status : int what_to_collect
+  | Collect_stdout : string what_to_collect
+  | Collect_stderr : string what_to_collect
+  | Collect_stdout_stderr : (string * string) what_to_collect
+  | Collect_stdout_status : (string * int) what_to_collect
+  | Collect_stderr_status : (string * int) what_to_collect
+  | Collect_everything : (string * string * int) what_to_collect
 
 let resolve_in_path prog =
   (* Do not try to resolve in the path if the program is something like
@@ -303,19 +303,19 @@ let stderr_to_stdout cmd = ErrToOut cmd
 
 (* === Collection facilities === *)
 
-let status = Col_status
+let status = Collect_status
 
-let stdout = Col_stdout
+let stdout = Collect_stdout
 
-let stderr = Col_stderr
+let stderr = Collect_stderr
 
-let stdout_and_stderr = Col_stdout_stderr
+let stdout_and_stderr = Collect_stdout_stderr
 
-let stdout_and_status = Col_stdout_status
+let stdout_and_status = Collect_stdout_status
 
-let stderr_and_status = Col_stderr_status
+let stderr_and_status = Collect_stderr_status
 
-let everything = Col_everything
+let everything = Collect_everything
 
 (* Opens a pipe for selected outputs and returns them optionally
  * after executing the command *)
@@ -342,10 +342,10 @@ let collect_gen ?cwd ?env (sel_stdout, sel_stderr) cmd =
 
 (* Should we collect stdout, stderr ? *)
 let selector_switch : type a. a what_to_collect -> bool * bool = function
-  | Col_status -> (false, false)
-  | Col_stdout | Col_stdout_status -> (true, false)
-  | Col_stderr | Col_stderr_status -> (false, true)
-  | Col_stdout_stderr | Col_everything -> (true, true)
+  | Collect_status -> (false, false)
+  | Collect_stdout | Collect_stdout_status -> (true, false)
+  | Collect_stderr | Collect_stderr_status -> (false, true)
+  | Collect_stdout_stderr | Collect_everything -> (true, true)
 
 (* Take the collected status and potential stdout/stderr streams, return the
  * expected output of collect *)
@@ -353,13 +353,13 @@ let pack :
     type a. int -> string option * string option -> a what_to_collect -> a =
  fun status (stdout, stderr) collection ->
   match (collection, stdout, stderr) with
-  | Col_status, _, _ -> status
-  | Col_stdout, Some x, _ -> x
-  | Col_stdout_status, Some x, _ -> (x, status)
-  | Col_stderr, _, Some x -> x
-  | Col_stderr_status, _, Some x -> (x, status)
-  | Col_stdout_stderr, Some x, Some y -> (x, y)
-  | Col_everything, Some x, Some y -> (x, y, status)
+  | Collect_status, _, _ -> status
+  | Collect_stdout, Some x, _ -> x
+  | Collect_stdout_status, Some x, _ -> (x, status)
+  | Collect_stderr, _, Some x -> x
+  | Collect_stderr_status, _, Some x -> (x, status)
+  | Collect_stdout_stderr, Some x, Some y -> (x, y)
+  | Collect_everything, Some x, Some y -> (x, y, status)
   | _ -> failwith "Did not collect the expected outputs"
 
 (* Take an input channel and read everything into a single string *)

--- a/feather.ml
+++ b/feather.ml
@@ -318,7 +318,7 @@ let stderr_and_status = Collect_stderr_status
 let everything = Collect_everything
 
 (* Opens a pipe for selected outputs and returns them optionally
- * after executing the command *)
+   after executing the command *)
 let collect_gen ?cwd ?env (sel_stdout, sel_stderr) cmd =
   let f def cond =
     if cond then
@@ -363,7 +363,7 @@ let pack :
   | _ -> failwith "Did not collect the expected outputs"
 
 (* Take an input channel and read everything into a single string *)
-let collect_all' chan =
+let collect_all chan =
   let out = In_channel.input_all chan in
   (* This might be controversial. The alternative is to export a [trim]
      command, that makes it easy to do this manually, but I think this
@@ -376,9 +376,8 @@ let collect ?cwd ?env collection cmd =
     collect_gen ?cwd ?env (selector_switch collection) cmd
   in
   (* Transform collected channels into strings *)
-  let prepare = Option.map ~f:collect_all' in
-  let stdout = prepare stdout_reader in
-  let stderr = prepare stderr_reader in
+  let stdout = Option.map stdout_reader ~f:collect_all in
+  let stderr = Option.map stderr_reader ~f:collect_all in
   (* Pack everything in the GADT type *)
   pack status (stdout, stderr) collection
 

--- a/feather.mli
+++ b/feather.mli
@@ -94,19 +94,38 @@ val or_ : cmd -> cmd -> cmd
 val sequence : cmd -> cmd -> cmd
 (** [ sequence ] is feather's version of a ";" in bash. See Infix module for more. *)
 
-val collect_stdout : ?cwd:string -> ?env:(string * string) list -> cmd -> string
-
-val collect_lines :
-  ?cwd:string -> ?env:(string * string) list -> cmd -> string list
-
 val map_lines : f:(string -> string) -> cmd
 
 val filter_lines : f:(string -> bool) -> cmd
 (** [map] within a series of pipes will be run in a thread.  *)
 
-val run : ?cwd:string -> ?env:(string * string) list -> cmd -> unit
+val lines : string -> string list
+(** Transforms a string into the list of its lines *)
 
+type 'a what_to_collect
+(** The type that determines what should be returned by {!collect} *)
+
+val stdout : string what_to_collect
+val stderr : string what_to_collect
+val status : int what_to_collect
+val everything : (string * string * int) what_to_collect
+val stdout_and_stderr : (string * string) what_to_collect
+val stdout_and_status : (string * int) what_to_collect
+val stderr_and_status : (string * int) what_to_collect
+
+(** Various collection possibilities, to be used with {!collect} *)
+
+val collect : ?cwd:string -> ?env:(string * string) list ->
+  'a what_to_collect -> cmd -> 'a
+(** [ collect col cmd ] runs [cmd], collecting the outputs specified by [col]
+    along the way and returning them. The return type depends on what is
+    collected. *)
+
+val run : ?cwd:string -> ?env:(string * string) list -> cmd -> unit
 val run_bg : ?cwd:string -> ?env:(string * string) list -> cmd -> unit
+(** Run a command in foreground or background without capturing anything.
+The exit status is lost. *)
+
 (** Run the process in a thread. Use [wait] to ensure that the parent
  won't exit, subsequently killing the background process. *)
 
@@ -160,9 +179,6 @@ val stderr_to_stdout : cmd -> cmd
     [flip_stdout_and_stderr] should be easy to write if anyone should need it. *)
 
 (* === Misc === *)
-
-val last_exit : unit -> int
-(** [last_exit] returns the exit status of the last child process to have exited *)
 
 val devnull : string
 (** [devnull] is easier to type than "/dev/null" *)

--- a/feather.mli
+++ b/feather.mli
@@ -108,10 +108,12 @@ type 'a what_to_collect
 val stdout : string what_to_collect
 val stderr : string what_to_collect
 val status : int what_to_collect
-val everything : (string * string * int) what_to_collect
 val stdout_and_stderr : (string * string) what_to_collect
 val stdout_and_status : (string * int) what_to_collect
 val stderr_and_status : (string * int) what_to_collect
+
+type everything = { stdout : string ; stderr : string ; status : int }
+val everything : everything what_to_collect
 
 (** Various collection possibilities, to be used with {!collect} *)
 


### PR DESCRIPTION
This is meant to solve https://github.com/charlesetc/feather/issues/6 and more

So, there is a lot going on here, and there are several questions I have to clarify how we want to finalize everything. But first let me describe what this PR contains a bit.

As expected, there is now a small GADT system to select what we want to capture when running a command. It is simpler than the one described in the issue since I thought it was a better compromise to not over-engineer the code and keep a nice interface.

There are now two running commands (or three if we count `run_bg`): `run` and `collect`.
- `run` runs the command as usual, does not capture anything and forgets its exit status. It returns unit.
- `collect` takes a function which is a composition of `stdout`, `stderr`, `stdout_lines` and `stderr_lines` (the composition operator is `<+>` since `>>` is already taken. It captures only the selected ouputs and returns a record `{stdout; stderr; status}` where `status` is always present (an integer), and `sdout/stderr` fields have the abstract type `not_collected` if not selected, and type `string` or `string list` if selected, depending on if we want lines or not.

An example :
```ocaml
ls "." |> run;


let {stdout; _} = ls "." |> collect stderr in ...
(* This does not compile since stdout has type not_collected!*)
(* print_endline stdout *)

let {stdout; _} = ls "." |> collect stdout_lines in ...
(* stdout = ["a"; "b"; ...] *)
(* stderr is not usable *)

let {stderr; status; _} = ls "thisdoesnotexist" |> collect stderr in
(* stderr = "ls: cannot access 'thisdoesnotexist': No such file or directory" *)
(* status = 2 *)

let {stderr; stdout; status} = ls "." |. ls "thisdoesnotexist" |> collect (stdout <+> stderr) in
(* stdout, stderr and status are all defined with the previous values *)

(* We can also capture nothing and just get the status *)
let {status; _} = ls "." |> collect only_status in
(* status = 0 *)
```

To accomplish that, the exit status is now propagated along the evaluation of the AST: `last_exit` has been removed externally and internally. Hence the status is truly lost if we use `run` for example.

-----------

That led me down the rabbit hole of background execution (which was one of the motivation of the original issue). I realized with the help of @tmarti2 that it was fundamentally broken since the addition of the new operators `&&.`, `||.` and co.
The original behavior for the `background` flag is to spawn each individual process of the pipeline in its own thread (and then we lost its exit status). However since `&&.` and `||.` use that exit status to determine if we should run the right-hand side, running those operators in background was completely broken.
Worse, since piping two commands `A | B` runs `A` in the background, the same problems arise if `A` contains `&&.` or `||.`

To fix all that, this PR implements the following approach:
- `process` (and `filter_map`) never spawns its own thread
- if we use `run_bg`, the entire `eval` of the AST is done in its own thread
- when piping `A | B`, the entire evaluation of `A` is done in its own thread (rather than only sub processes)

This way, even if a command is run in background (or is the left-hand side of a pipe), the exit status is correctly managed. As a consequence, `background` is removed from the context (since it's only used at two locations).

I added some tests for all that as well as a bit a code in `example.ml`

---------

Some thoughts:
- what do you think about the user interface for `collect`? Clearly it's not the only way to do it.
- for now I left the old functions `collect_stdout` and `collect_lines`, defined as specialized versions of `collect`. Do we want to keep them ? (and if so, with the same name ?)
- the composition operator is `<+>`. Is that OK?
- currently if we want to only collect the status, we have to pass the identity function to `collect` (and I made a named identity function called `only_status`). Do we want to keep it like that? Use an optional parameter (but then we have to name it everywhere)?
- the `stdout` and `stderr` collide with `Base.stdout`. Keep it like that or rename them? (and with what names?)