### PR TITLE
Fix background issue

### DIFF
--- a/feather.ml
+++ b/feather.ml
@@ -108,14 +108,14 @@ let filter_map ~f ctx =
   fd_iter_lines ctx.stdin_reader ~f:(fun line ->
       match f line with
       | Some out ->
-        let buf = Bytes.of_string out in
-        let (_ : int) =
-          Unix.write ctx.stdout_writer buf 0 (Bytes.length buf)
-        in
-        let (_ : int) =
-          Unix.write ctx.stdout_writer (Bytes.of_string "\n") 0 1
-        in
-        ()
+          let buf = Bytes.of_string out in
+          let (_ : int) =
+            Unix.write ctx.stdout_writer buf 0 (Bytes.length buf)
+          in
+          let (_ : int) =
+            Unix.write ctx.stdout_writer (Bytes.of_string "\n") 0 1
+          in
+          ()
       | None -> ());
   Unix.close ctx.stdout_writer
 
@@ -146,8 +146,8 @@ let exec prog args ctx =
   let stat =
     match snd (Unix.waitpid [] pid) with
     | WEXITED s -> s
-    | WSIGNALED s
-    | WSTOPPED s -> 128 + s (* using common convention *)
+    | WSIGNALED s | WSTOPPED s -> 128 + s
+    (* using common convention *)
   in
   Unix.close ctx.stdout_writer;
   Unix.close ctx.stderr_writer;
@@ -160,55 +160,58 @@ let rec eval cmd ctx =
   match cmd with
   | Process (name, args) -> exec name args ctx
   | Pipe (a, b) ->
-    let pipe_reader, pipe_writer = Spawn.safe_pipe () in
-    Thread.run (fun () ->
-        eval a {
-          ctx with
-          stdout_writer = pipe_writer;
-          stderr_writer = Unix.dup ctx.stderr_writer;
-        } (* Left side of pipe is executed in background *)
-      );
-    eval b { ctx with stdin_reader = pipe_reader }
+      let pipe_reader, pipe_writer = Spawn.safe_pipe () in
+      Thread.run (fun () ->
+          eval a
+            {
+              ctx with
+              stdout_writer = pipe_writer;
+              stderr_writer = Unix.dup ctx.stderr_writer;
+            }
+          (* Left side of pipe is executed in background *));
+      eval b { ctx with stdin_reader = pipe_reader }
   | And (a, b) ->
-    let a_stat = eval a {
-        ctx with
-        stdout_writer = Unix.dup ctx.stdout_writer;
-        stderr_writer = Unix.dup ctx.stderr_writer;
-        stdin_reader = Unix.dup ctx.stdin_reader
-      }
-    in
-    if success_status a_stat
-    then eval b ctx
-    else (
-      Unix.close ctx.stdout_writer;
-      Unix.close ctx.stderr_writer;
-      Unix.close ctx.stdin_reader;
-      a_stat
-    )
+      let a_stat =
+        eval a
+          {
+            ctx with
+            stdout_writer = Unix.dup ctx.stdout_writer;
+            stderr_writer = Unix.dup ctx.stderr_writer;
+            stdin_reader = Unix.dup ctx.stdin_reader;
+          }
+      in
+      if success_status a_stat then eval b ctx
+      else (
+        Unix.close ctx.stdout_writer;
+        Unix.close ctx.stderr_writer;
+        Unix.close ctx.stdin_reader;
+        a_stat)
   | Or (a, b) ->
-    let a_stat = eval a {
-        ctx with
-        stdout_writer = Unix.dup ctx.stdout_writer;
-        stderr_writer = Unix.dup ctx.stderr_writer;
-        stdin_reader = Unix.dup ctx.stdin_reader
-      }
-    in
-    if success_status a_stat
-    then (
-      Unix.close ctx.stdout_writer;
-      Unix.close ctx.stderr_writer;
-      Unix.close ctx.stdin_reader;
-      a_stat
-    )
-    else eval b ctx
+      let a_stat =
+        eval a
+          {
+            ctx with
+            stdout_writer = Unix.dup ctx.stdout_writer;
+            stderr_writer = Unix.dup ctx.stderr_writer;
+            stdin_reader = Unix.dup ctx.stdin_reader;
+          }
+      in
+      if success_status a_stat then (
+        Unix.close ctx.stdout_writer;
+        Unix.close ctx.stderr_writer;
+        Unix.close ctx.stdin_reader;
+        a_stat)
+      else eval b ctx
   | Sequence (a, b) ->
-    ignore (eval a {
-        ctx with
-        stdout_writer = Unix.dup ctx.stdout_writer;
-        stderr_writer = Unix.dup ctx.stderr_writer;
-        stdin_reader = Unix.dup ctx.stdin_reader
-      });
-    eval b ctx
+      ignore
+        (eval a
+           {
+             ctx with
+             stdout_writer = Unix.dup ctx.stdout_writer;
+             stderr_writer = Unix.dup ctx.stderr_writer;
+             stdin_reader = Unix.dup ctx.stdin_reader;
+           });
+      eval b ctx
   | WriteOutTo (str, cmd) ->
       Unix.close ctx.stdout_writer;
       let stdout_writer =
@@ -242,7 +245,9 @@ let rec eval cmd ctx =
       Unix.close ctx.stderr_writer;
       let stderr_writer = Unix.dup ctx.stdout_writer in
       eval cmd { ctx with stderr_writer }
-  | FilterMap f -> filter_map ~f ctx; 0
+  | FilterMap f ->
+      filter_map ~f ctx;
+      0
 
 let process name args = Process (name, args)
 
@@ -292,13 +297,15 @@ let stderr_to_stdout cmd = ErrToOut cmd
 
 let collect_gen ?cwd ?env cmd =
   let stdout_reader, stdout_writer = Unix.pipe () in
-  let status = eval cmd {
-      stdin_reader = Unix.dup Unix.stdin;
-      stdout_writer;
-      stderr_writer = Unix.dup Unix.stderr;
-      cwd;
-      env;
-    }
+  let status =
+    eval cmd
+      {
+        stdin_reader = Unix.dup Unix.stdin;
+        stdout_writer;
+        stderr_writer = Unix.dup Unix.stderr;
+        cwd;
+        env;
+      }
   in
   State.exit := status;
   Unix.in_channel_of_descr stdout_reader
@@ -320,16 +327,19 @@ let filter_lines ~f = FilterMap (fun a -> if f a then Some a else None)
 let run' ?cwd ?env ~background cmd =
   Caml.flush_all ();
   let go () =
-    eval cmd {
-      stdin_reader = Unix.dup Unix.stdin;
-      stdout_writer = Unix.dup Unix.stdout;
-      stderr_writer = Unix.dup Unix.stderr;
-      cwd;
-      env;
-    }
+    eval cmd
+      {
+        stdin_reader = Unix.dup Unix.stdin;
+        stdout_writer = Unix.dup Unix.stdout;
+        stderr_writer = Unix.dup Unix.stderr;
+        cwd;
+        env;
+      }
   in
   if background then Thread.run go
-  else let stat = go () in State.exit := stat
+  else
+    let stat = go () in
+    State.exit := stat
 
 let run_bg ?cwd ?env = run' ?cwd ?env ~background:true
 

--- a/feather.ml
+++ b/feather.ml
@@ -171,7 +171,7 @@ let rec eval cmd ctx =
           (* Left side of pipe is executed in background *));
       eval b { ctx with stdin_reader = pipe_reader }
   | And (a, b) ->
-      let a_stat =
+      let a_status =
         eval a
           {
             ctx with
@@ -180,14 +180,14 @@ let rec eval cmd ctx =
             stdin_reader = Unix.dup ctx.stdin_reader;
           }
       in
-      if success_status a_stat then eval b ctx
+      if success_status a_status then eval b ctx
       else (
         Unix.close ctx.stdout_writer;
         Unix.close ctx.stderr_writer;
         Unix.close ctx.stdin_reader;
-        a_stat)
+        a_status)
   | Or (a, b) ->
-      let a_stat =
+      let a_status =
         eval a
           {
             ctx with
@@ -196,11 +196,11 @@ let rec eval cmd ctx =
             stdin_reader = Unix.dup ctx.stdin_reader;
           }
       in
-      if success_status a_stat then (
+      if success_status a_status then (
         Unix.close ctx.stdout_writer;
         Unix.close ctx.stderr_writer;
         Unix.close ctx.stdin_reader;
-        a_stat)
+        a_status)
       else eval b ctx
   | Sequence (a, b) ->
       ignore

--- a/feather.ml
+++ b/feather.ml
@@ -143,7 +143,7 @@ let exec prog args ctx =
     Spawn.spawn ~cwd ?env ~stdin:ctx.stdin_reader ~stdout:ctx.stdout_writer
       ~stderr:ctx.stderr_writer ~prog ~argv ()
   in
-  let stat =
+  let status =
     match snd (Unix.waitpid [] pid) with
     | WEXITED s -> s
     | WSIGNALED s | WSTOPPED s -> 128 + s
@@ -152,7 +152,7 @@ let exec prog args ctx =
   Unix.close ctx.stdout_writer;
   Unix.close ctx.stderr_writer;
   Unix.close ctx.stdin_reader;
-  stat
+  status
 
 let success_status x = x = 0
 
@@ -338,8 +338,8 @@ let run' ?cwd ?env ~background cmd =
   in
   if background then Thread.run go
   else
-    let stat = go () in
-    State.exit := stat
+    let status = go () in
+    State.exit := status
 
 let run_bg ?cwd ?env = run' ?cwd ?env ~background:true
 


### PR DESCRIPTION
This PR should fix background issues mentionned in PR #10 and issue #6 .
Here I choosed to ignore exit code from background commands.
`State.exit` (and `last_exit ()`) will be updated when you run either
- collect_stdout
- collect_lines
- run

Wait for @Firobe reviews to make sure I did not do mistakes ;)