### PR TITLE
Basic support for native Windows

### DIFF
--- a/src/feather.ml
+++ b/src/feather.ml
@@ -127,9 +127,10 @@ type _ what_to_collect =
 let resolve_in_path prog =
   (* Do not try to resolve in the path if the program is something like
    * ./this.exe *)
-  if String.split ~on:'/' prog |> List.length <> 1 then Some prog
+  if (String.split ~on:'/' prog |> List.length <> 1) || (String.split ~on:'\\' prog |> List.length <> 1) then Some prog
   else
-    let paths = Sys.getenv "PATH" |> String.split ~on:':' in
+    let path_separator = if (Sys.win32 && (not Sys.cygwin)) then ';' else ':' in
+    let paths = Sys.getenv "PATH" |> String.split ~on:path_separator in
     List.map paths ~f:(fun d -> Caml.Filename.concat d prog)
     |> List.find ~f:Caml.Sys.file_exists
 

--- a/src/feather.ml
+++ b/src/feather.ml
@@ -325,7 +325,15 @@ let rec eval cmd ctx =
       filter_mapi ~f ctx;
       0
 
-let process name args = Process (name, args)
+let process name args =
+  if (Sys.win32 && (not Sys.cygwin)) then
+    let name_with_exe =
+      String.chop_suffix_if_exists ~suffix:".exe"
+        (String.chop_suffix_if_exists ~suffix:".EXE" name)
+    in
+    Process (name_with_exe ^ ".exe", args)
+  else
+    Process (name, args)
 
 let ( |. ) a b = Pipe (a, b)
 


### PR DESCRIPTION
The first commit allows the following on native Windows:

```ocaml
#require "feather";;
open Feather;;
process "ps.exe" [] |> collect stdout;; 
```

Notice that `ps.exe` is required for Windows executables (on my system `ps.exe` comes from MSYS2; theoretically all your examples should work on MSYS2).

--- 

The second commit is to add the `.exe`` suffix to all executables on Windows if it doesn't have .exe already.

---

The `let () = Caml.at_exit terminate_child_processes` requires that `pgrep` is available to feather. That means native Windows users must have MSYS2. I've added `pgrep` to the next release of [Diskuv OCaml](https://diskuv.gitlab.io/diskuv-ocaml/) which I [recently announced](https://discuss.ocaml.org/t/ann-windows-friendly-ocaml-4-12-distribution-diskuv-ocaml-0-1-0/8358); that way native Windows users can use `feather` out of the box.

Thanks for the nice tool!