### PR TITLE
Collect outputs asynchronously + fix FD leak

### DIFF
--- a/src/feather.ml
+++ b/src/feather.ml
@@ -768,6 +768,16 @@ hi
         == Stderr ==
         |}]
 
+    let%expect_test "large collection" =
+      let to_run () =
+        ignore (process "dd" [ "if=/dev/zero"; "of=/dev/stdout"; "bs=1000000"; "count=1" ]
+                |> stderr_to_stdout |> collect stdout);
+        printf "collection done!\n"
+      in Thread.run to_run; Thread.delay 2.0;
+      [%expect {|
+        collection done!
+    |}]
+
     let%expect_test "of_list" =
       of_list [ "one"; "two"; "three" ] |. sort |> print;
       [%expect {|

--- a/src/feather.ml
+++ b/src/feather.ml
@@ -387,6 +387,7 @@ let everything = Collect_everything
 (* Take a file descriptor and read everything into a single string *)
 let collect_into_string fd =
   let out = In_channel.input_all (Unix.in_channel_of_descr fd) in
+  Unix.close fd;
   (* This might be controversial. The alternative is to export a [trim]
      command, that makes it easy to do this manually, but I think this
      is actually less surprising than keeping the newline. *)


### PR DESCRIPTION
Fixes https://github.com/charlesetc/feather/issues/24

Collecting stdout and stderr is now done in separate threads in order to avoid blocking if the program outputs more than the pipe capacity. Events are used to communicate between threads.

Add a test for the issue.