### PR TITLE
Add a depext on procps/proctools

### DIFF
--- a/feather.opam
+++ b/feather.opam
@@ -31,3 +31,8 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+depexts: [
+  # For pgrep
+  ["procps"] {os-family = "debian"}
+  ["procps-ng"] {os = "linux" & os-distribution = "archlinux"}
+]

--- a/feather.opam.template
+++ b/feather.opam.template
@@ -11,3 +11,8 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+depexts: [
+  # For pgrep
+  ["procps"] {os-family = "debian"}
+  ["procps-ng"] {os = "linux" & os-distribution = "archlinux"}
+]


### PR DESCRIPTION
Feather uses pgrep (in src/feather.ml), which is not necessarily
installed on the system. It is part of procps package on Debian and
proctools on homebrew.

Add the relevant depexts.

Closes https://github.com/charlesetc/feather/issues/26
