### PR TITLE
Compatibility with base 0.13 and dependency cleanup

### DIFF
--- a/async/dune
+++ b/async/dune
@@ -3,4 +3,4 @@
  (public_name feather_async)
  (inline_tests)
  (libraries base async feather)
- (preprocess (pps ppx_let ppx_expect ppx_string)))
+ (preprocess (pps ppx_let ppx_expect)))

--- a/dune-project
+++ b/dune-project
@@ -16,9 +16,12 @@
   (depends
    (ocaml (>= 4.08))
    dune
-   (base (>= 0.14.0))
-   (ppx_expect (>= 0.14.0))
-   (stdio (>= 0.14.0))
+   (base (>= 0.13.0))
+   ppx_expect
+   (ppx_string :with-test)
+   (ppx_let :with-test)
+   (ppx_sexp_message :with-test)
+   stdio
    (spawn (>= 0.13.0))))
 
 (package

--- a/feather.opam
+++ b/feather.opam
@@ -11,9 +11,12 @@ bug-reports: "https://github.com/charlesetc/feather/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
-  "base" {>= "0.14.0"}
-  "ppx_expect" {>= "0.14.0"}
-  "stdio" {>= "0.14.0"}
+  "base" {>= "0.13.0"}
+  "ppx_expect"
+  "ppx_string" {with-test}
+  "ppx_let" {with-test}
+  "ppx_sexp_message" {with-test}
+  "stdio"
   "spawn" {>= "0.13.0"}
   "odoc" {with-doc}
 ]

--- a/src/feather.ml
+++ b/src/feather.ml
@@ -391,7 +391,9 @@ let collect_into_string_sync fd =
   (* This might be controversial. The alternative is to export a [trim]
      command, that makes it easy to do this manually, but I think this
      is actually less surprising than keeping the newline. *)
-  String.chop_suffix_if_exists out ~suffix:"\n"
+  match String.chop_suffix out ~suffix:"\n" with
+  | Some trimmed -> trimmed
+  | None -> out
 
 (* Same thing but do it in another thread, returning an event which will contain
  * the string *)


### PR DESCRIPTION
This PR changes one line in `feather.ml` to achieve compatibility with base 0.13 (where I currently need it).

Moreover, it removes unneeded dependencies in `async/dune` and add all dependencies needed to build the examples in `dune-project` (and hence in `*.opam`), with the `with-test` flag.