### PR TITLE
fix: Unix.kill argument order

### DIFF
--- a/src/feather.ml
+++ b/src/feather.ml
@@ -635,7 +635,7 @@ let terminate_child_processes () =
   process "pgrep" [ "-P"; Int.to_string State.pid ]
   |> collect stdout |> lines |> List.map ~f:Int.of_string
   |> List.iter ~f:(fun pid ->
-         try Unix.kill Sys.sigterm pid
+         try Unix.kill pid Sys.sigterm
          with Unix.Unix_error (Unix.ESRCH, _, _) ->
            (* [Unix.ERSCH] is raised when a process cannot be found, which
             * means that the child has already terminated, so it should


### PR DESCRIPTION
Fixes #20

See https://github.com/charlesetc/feather/issues/20#issuecomment-2058675291.

Looks like this regression was introduced when switching from `core` to `base`: https://github.com/charlesetc/feather/commit/27dfe0dd92a66ac247d31682850b625f4b3f4fcb#diff-a2a54b6a7debfa72749133bb3bf30708128f2d98e60fe8063444cbdf7791cbd8R354