### PR TITLE
Ocamlformat config

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,3 @@
+version=0.28.1
+profile=janestreet
+parse-docstrings=true

--- a/async/feather_async.ml
+++ b/async/feather_async.ml
@@ -2,12 +2,10 @@ open! Base
 open! Async
 
 let run_in_background = `Use_don't_wait_for
-
 let collect_in_background = `Use_don't_wait_for
-
 let run ?cwd ?env cmd = In_thread.run (fun () -> Feather.run ?cwd ?env cmd)
-
 let fzf ?cwd ?env cmd = In_thread.run (fun () -> Feather.fzf ?cwd ?env cmd)
 
 let collect ?cwd ?env what_to_collect cmd =
   In_thread.run (fun () -> Feather.collect ?cwd ?env what_to_collect cmd)
+;;

--- a/async/feather_async.mli
+++ b/async/feather_async.mli
@@ -2,34 +2,33 @@ open Async
 
 (** Feather_async provides functions to run Feather cmd's within an Async context. *)
 
-val run :
-  ?cwd:string -> ?env:(string * string) list -> Feather.cmd -> unit Deferred.t
+val run : ?cwd:string -> ?env:(string * string) list -> Feather.cmd -> unit Deferred.t
 
-val collect :
-  ?cwd:string ->
-  ?env:(string * string) list ->
-  'a Feather.what_to_collect ->
-  Feather.cmd ->
-  'a Deferred.t
+val collect
+  :  ?cwd:string
+  -> ?env:(string * string) list
+  -> 'a Feather.what_to_collect
+  -> Feather.cmd
+  -> 'a Deferred.t
 
-val fzf :
-  ?cwd:string ->
-  ?env:(string * string) list ->
-  Feather.cmd ->
-  string option Deferred.t
+val fzf
+  :  ?cwd:string
+  -> ?env:(string * string) list
+  -> Feather.cmd
+  -> string option Deferred.t
 
 val run_in_background : [ `Use_don't_wait_for ]
-  [@@alert
-    run_bg
-      {|  [Feather_async.run_in_background] intentionally shadows [Feather.run_in_background].
+[@@alert
+  run_bg
+    {|  [Feather_async.run_in_background] intentionally shadows [Feather.run_in_background].
 
           When using [Feather_async], use [Async.don't_wait_for] to run things
           asynchronously. |}]
 
 val collect_in_background : [ `Use_don't_wait_for ]
-  [@@alert
-    run_bg
-      {|  [Feather_async.collect_in_background] intentionally shadows [Feather.collect_in_background].
+[@@alert
+  run_bg
+    {|  [Feather_async.collect_in_background] intentionally shadows [Feather.collect_in_background].
 
           When using [Feather_async], use [Async.don't_wait_for] to run things
           asynchronously. |}]

--- a/example/async_example.ml
+++ b/example/async_example.ml
@@ -12,8 +12,11 @@ let main () : unit Deferred.t =
   match%bind ls "/tmp" < devnull |> fzf with
   | Some s -> echo [%string "hi there: %{s}"] |> run
   | None -> echo "got nothing" |> run
+;;
 
 let () =
   Command_unix.run
-  @@ Command.async ~summary:"example feather async command"
+  @@ Command.async
+       ~summary:"example feather async command"
        (Command.Param.return (fun () -> main ()))
+;;

--- a/example/example.ml
+++ b/example/example.ml
@@ -4,13 +4,22 @@ open Feather
 open Feather.Infix
 
 let __ () =
-  cat "dune" |. rg "feather" |> stdout_to_stderr |. echo "hi" |. sort
-  > "/tmp/out" |. uniq |. rg "h" |> run
+  cat "dune"
+  |. rg "feather"
+  |> stdout_to_stderr
+  |. echo "hi"
+  |. sort
+  > "/tmp/out"
+  |. uniq
+  |. rg "h"
+  |> run
+;;
 
 let __ () =
   match ls "." < devnull |> fzf with
   | Some s -> printf "hi there: %s\n" s
   | None -> printf "got nothing\n"
+;;
 
 let __ () = process "tail" [ "-n"; "2" ] < "dune-project" |. rg "w" |> run
 
@@ -20,12 +29,11 @@ let __ () =
     cat "/usr/share/dict/words" |. shuf |. head 5 > output |> run;
     match tr "a-z" "A-Z" < output |> collect stdout |> lines with
     | [ a; b; c; d; e ] ->
-        (printf "You are a %s %s and I think this is the %s %s of all %s.\n")
-          a b c d e
+      (printf "You are a %s %s and I think this is the %s %s of all %s.\n") a b c d e
     | _ -> failwith "head 5"
   done;
-
   ls "/tmp" |. grep "output" |> run
+;;
 
 let __ () =
   let open Core in
@@ -37,20 +45,22 @@ let __ () =
   |. cut' [ 8 ]
   |. filter_lines ~f:(fun line -> String.( <> ) line "")
   |. map_lines ~f:(fun line ->
-         Time.Ofday.of_string line |> Time.Ofday.to_span_since_start_of_day
-         |> Time.Span.to_hr |> Float.to_int
-         |> function
-         | n when n > 12 -> Int.to_string (n - 12) ^ " PM"
-         | n -> Int.to_string n ^ " AM")
+    Time.Ofday.of_string line
+    |> Time.Ofday.to_span_since_start_of_day
+    |> Time.Span.to_hr
+    |> Float.to_int
+    |> function
+    | n when n > 12 -> Int.to_string (n - 12) ^ " PM"
+    | n -> Int.to_string n ^ " AM")
   |. process "sort" [ "-n" ]
   |. process "uniq" [ "-c" ]
   |> run
+;;
 
 let __ () =
-  let stderr, status =
-    ls "thisfiledoesnotexists" |> collect stderr_and_status
-  in
+  let stderr, status = ls "thisfiledoesnotexists" |> collect stderr_and_status in
   printf "ls returned error code %d: %s\n" status stderr
+;;
 
 let __ () = ls "." |> run ~cwd:"_build"
 
@@ -61,11 +71,16 @@ let __ () =
   in
   printf "*** %s ***\n" stderr;
   print_endline stdout
+;;
 
 let __ () =
   Feather.of_list [ "duck"; "goose"; "duck" ]
   |. Feather.map_lines ~f:(fun s -> "*** " ^ s)
-  |. sort |> collect stdout |> lines |> List.iter ~f:print_endline
+  |. sort
+  |> collect stdout
+  |> lines
+  |> List.iter ~f:print_endline
+;;
 
 let __ () =
   let process =
@@ -73,31 +88,30 @@ let __ () =
     |> run_in_background
   in
   ignore process
+;;
 
 let __ () =
   let p1 =
-    process "bash"
-      [ "-c"; "for i in `seq 1 5` ; do echo a $i ; sleep 1 ; done" ]
+    process "bash" [ "-c"; "for i in `seq 1 5` ; do echo a $i ; sleep 1 ; done" ]
     |> run_in_background
   in
   let _ =
     Thread.create
       (fun () ->
-        Feather.wait p1;
-        print_endline "p1 done")
+         Feather.wait p1;
+         print_endline "p1 done")
       ()
   in
   Unix.sleep 1;
   let p2 =
-    process "bash"
-      [ "-c"; "for i in `seq 6 10` ; do echo b $i ; sleep 1 ; done" ]
+    process "bash" [ "-c"; "for i in `seq 6 10` ; do echo b $i ; sleep 1 ; done" ]
     |> run_in_background
   in
   let _ =
     Thread.create
       (fun () ->
-        Feather.wait p2;
-        print_endline "p2 done")
+         Feather.wait p2;
+         print_endline "p2 done")
       ()
   in
   print_endline "main 98";
@@ -107,22 +121,24 @@ let __ () =
   Feather.wait p2;
   print_endline "main 100";
   Feather.wait p1
+;;
 
 let __ () =
   for i = 1 to 10 do
     process "bash" [ "-c"; [%string "sleep %{i#Int} ; echo %{i#Int}"] ]
-    |> run_in_background |> ignore
+    |> run_in_background
+    |> ignore
   done;
   Feather.wait_all ();
   print_endline "done"
+;;
 
 let () =
-  let p1 =
-    process "echo" [ "test" ] |> collect_in_background stdout_and_status
-  in
+  let p1 = process "echo" [ "test" ] |> collect_in_background stdout_and_status in
   print_endline "waiting now";
   let stdout, status = Feather.wait p1 in
   print_endline "==== stdout ====";
   print_endline stdout;
   print_endline "==== status ====";
   printf "%d\n" status
+;;

--- a/src/feather.ml
+++ b/src/feather.ml
@@ -1,7 +1,6 @@
 (* We bind [Mutex] in a way that satisfies all supported OCaml and Base versions:
    It must be bound to either [threads.Mutex] or [Stdlib.Mutex]. *)
 module Caml_mutex = Mutex
-
 open Base
 open Stdio
 module Sys = Stdlib.Sys
@@ -10,23 +9,28 @@ module Unix = struct
   include Unix
 
   let rec try_until_no_eintr f =
-    try f () with Unix.Unix_error (Unix.EINTR, _, _) -> try_until_no_eintr f
+    try f () with
+    | Unix.Unix_error (Unix.EINTR, _, _) -> try_until_no_eintr f
+  ;;
 
   let with_restart_on_eintr ?(restart = false) f =
     if restart then try_until_no_eintr f else f ()
+  ;;
 
   let dup = dup ~cloexec:true
-
   let pipe = pipe ~cloexec:true
 
   let read ?restart fd buf pos len =
     with_restart_on_eintr ?restart (fun () -> read fd buf pos len)
+  ;;
 
   let write ?restart fd buf pos len =
     with_restart_on_eintr ?restart (fun () -> write fd buf pos len)
+  ;;
 
   let waitpid ?(restart = true) wait_flags pid =
     with_restart_on_eintr ~restart (fun () -> waitpid wait_flags pid)
+  ;;
 end
 
 module Thread = struct
@@ -35,6 +39,7 @@ module Thread = struct
   let run f =
     let (_ : t) = create f () in
     ()
+  ;;
 end
 
 module Mutex = struct
@@ -43,17 +48,19 @@ module Mutex = struct
   let with_lock m f =
     Caml_mutex.lock m;
     Exn.protect ~f ~finally:(fun () -> Caml_mutex.unlock m)
+  ;;
 end
 
 module Background_process = struct
-  type 'a t = {
-    mutable result : 'a option;
-    condition : Condition.t;
-    mutex : Mutex.t;
-  }
+  type 'a t =
+    { mutable result : 'a option
+    ; condition : Condition.t
+    ; mutex : Mutex.t
+    }
 
   let create () =
     { condition = Condition.create (); mutex = Mutex.create (); result = None }
+  ;;
 
   type packed = T : _ t -> packed
 
@@ -64,40 +71,38 @@ type 'a background_process = 'a Background_process.t
 
 module State : sig
   val pid : int
-
   val new_background_process : unit -> 'a Background_process.t
-
   val all_background_processes : unit -> Background_process.packed list
 end = struct
   let pid = Unix.getpid ()
 
-  (* Not sure if this mutex is helpful but better safe than sorry?  *)
+  (* Not sure if this mutex is helpful but better safe than sorry? *)
   let background_process_mutex = Mutex.create ()
-
   let background_processes : Background_process.packed list ref = ref []
 
   let new_background_process () =
     Mutex.with_lock background_process_mutex (fun () ->
-        let process = Background_process.create () in
-        background_processes :=
-          Background_process.pack process :: !background_processes;
-        process)
+      let process = Background_process.create () in
+      background_processes := Background_process.pack process :: !background_processes;
+      process)
+  ;;
 
   let all_background_processes () =
     Mutex.with_lock background_process_mutex (fun () -> !background_processes)
+  ;;
 end
 
 let debug = ref false
 
 type env = (string * string) list
 
-type context = {
-  stdin_reader : Unix.file_descr;
-  stdout_writer : Unix.file_descr;
-  stderr_writer : Unix.file_descr;
-  cwd : string option;
-  env : env option;
-}
+type context =
+  { stdin_reader : Unix.file_descr
+  ; stdout_writer : Unix.file_descr
+  ; stderr_writer : Unix.file_descr
+  ; cwd : string option
+  ; env : env option
+  }
 
 type cmd =
   | Process of string * string list
@@ -117,7 +122,11 @@ type cmd =
 [@@deriving sexp]
 
 (* GADT type to accomplish dynamic return types for collect *)
-type everything = { stdout : string; stderr : string; status : int }
+type everything =
+  { stdout : string
+  ; stderr : string
+  ; status : int
+  }
 
 type _ what_to_collect =
   | Collect_status : int what_to_collect
@@ -131,16 +140,19 @@ type _ what_to_collect =
 let resolve_in_path prog =
   (* Do not try to resolve in the path if the program is something like
    * ./this.exe *)
-  if String.split ~on:'/' prog |> List.length <> 1 then Some prog
-  else
+  if String.split ~on:'/' prog |> List.length <> 1
+  then Some prog
+  else (
     let paths = Sys.getenv "PATH" |> String.split ~on:':' in
     List.map paths ~f:(fun d -> Stdlib.Filename.concat d prog)
-    |> List.find ~f:Stdlib.Sys.file_exists
+    |> List.find ~f:Stdlib.Sys.file_exists)
+;;
 
 let resolve_in_path_exn prog =
   match resolve_in_path prog with
   | None -> failwith (Printf.sprintf "no program in path %s" prog)
   | Some prog -> prog
+;;
 
 (* We need a way to iterate over the lines of a file descriptor,
    so that when it is closed, we can stop iterating. This is NOT the case for iterating
@@ -153,33 +165,31 @@ let fd_iter_lines ~f fd =
     while true do
       match Unix.read fd buf 0 1 with
       | 0 -> raise End_of_file
-      | 1 -> (
-          match Bytes.get buf 0 with
-          | '\n' ->
-              f (String.of_char_list (List.rev !line));
-              line := []
-          | c -> line := c :: !line)
+      | 1 ->
+        (match Bytes.get buf 0 with
+         | '\n' ->
+           f (String.of_char_list (List.rev !line));
+           line := []
+         | c -> line := c :: !line)
       | _ -> assert false
     done
-  with End_of_file ->
-    if List.length !line <> 0 then f (String.of_char_list (List.rev !line))
+  with
+  | End_of_file -> if List.length !line <> 0 then f (String.of_char_list (List.rev !line))
+;;
 
 let filter_mapi ~f ctx =
   let count = ref 0 in
   fd_iter_lines ctx.stdin_reader ~f:(fun line ->
-      (match f line !count with
-      | Some out ->
-          let buf = Bytes.of_string out in
-          let (_ : int) =
-            Unix.write ctx.stdout_writer buf 0 (Bytes.length buf)
-          in
-          let (_ : int) =
-            Unix.write ctx.stdout_writer (Bytes.of_string "\n") 0 1
-          in
-          ()
-      | None -> ());
-      Int.incr count);
+    (match f line !count with
+     | Some out ->
+       let buf = Bytes.of_string out in
+       let (_ : int) = Unix.write ctx.stdout_writer buf 0 (Bytes.length buf) in
+       let (_ : int) = Unix.write ctx.stdout_writer (Bytes.of_string "\n") 0 1 in
+       ()
+     | None -> ());
+    Int.incr count);
   Unix.close ctx.stdout_writer
+;;
 
 let exec prog args ctx =
   let argv = prog :: args in
@@ -188,24 +198,39 @@ let exec prog args ctx =
     match ctx.cwd with
     | None -> Inherit
     | Some cwd ->
-        prerr_endline cwd;
-        Path cwd
+      prerr_endline cwd;
+      Path cwd
   in
   let env : Spawn.Env.t option =
     Option.map ctx.env ~f:(fun env ->
-        List.map env ~f:(fun (key, value) -> Printf.sprintf "%s=%s" key value)
-        |> Spawn.Env.of_list)
+      List.map env ~f:(fun (key, value) -> Printf.sprintf "%s=%s" key value)
+      |> Spawn.Env.of_list)
   in
-  (if !debug then
-   let tm = Unix.localtime (Unix.time ()) in
-   eprintf "%d-%d-%d %d:%d:%d - %s %s\n" tm.tm_year tm.tm_mon tm.tm_mday
-     tm.tm_hour tm.tm_min tm.tm_sec prog
-     ("(" ^ String.concat ~sep:" " args ^ ")"));
+  if !debug
+  then (
+    let tm = Unix.localtime (Unix.time ()) in
+    eprintf
+      "%d-%d-%d %d:%d:%d - %s %s\n"
+      tm.tm_year
+      tm.tm_mon
+      tm.tm_mday
+      tm.tm_hour
+      tm.tm_min
+      tm.tm_sec
+      prog
+      ("(" ^ String.concat ~sep:" " args ^ ")"));
   let pid =
-    Spawn.spawn ~cwd ?env ~stdin:ctx.stdin_reader ~stdout:ctx.stdout_writer
-      ~stderr:ctx.stderr_writer ~prog ~argv ()
+    Spawn.spawn
+      ~cwd
+      ?env
+      ~stdin:ctx.stdin_reader
+      ~stdout:ctx.stdout_writer
+      ~stderr:ctx.stderr_writer
+      ~prog
+      ~argv
+      ()
   in
-  (* Wait for process and return its status  *)
+  (* Wait for process and return its status *)
   let status =
     match snd (Unix.waitpid [] pid) with
     | WEXITED s -> s
@@ -216,6 +241,7 @@ let exec prog args ctx =
   Unix.close ctx.stdout_writer;
   Unix.close ctx.stderr_writer;
   status
+;;
 
 let success_status = 0
 
@@ -226,6 +252,7 @@ let exec_list list ctx =
   Out_channel.close stdout_channel;
   Unix.close ctx.stderr_writer;
   success_status
+;;
 
 let rec eval cmd ctx =
   (* This can be useful for debugging feather evaluation *)
@@ -235,161 +262,132 @@ let rec eval cmd ctx =
   | Process (name, args) -> exec name args ctx
   | Of_list list -> exec_list list ctx
   | Pipe (a, b) ->
-      let pipe_reader, pipe_writer = Spawn.safe_pipe () in
-      Thread.run (fun () ->
-          (* Waiting on this closes the file handles. *)
-          let _status =
-            eval a
-              {
-                ctx with
-                stdout_writer = pipe_writer;
-                stderr_writer = Unix.dup ctx.stderr_writer;
-              }
-          in
-          ());
-      eval b { ctx with stdin_reader = pipe_reader }
+    let pipe_reader, pipe_writer = Spawn.safe_pipe () in
+    Thread.run (fun () ->
+      (* Waiting on this closes the file handles. *)
+      let _status =
+        eval
+          a
+          { ctx with
+            stdout_writer = pipe_writer
+          ; stderr_writer = Unix.dup ctx.stderr_writer
+          }
+      in
+      ());
+    eval b { ctx with stdin_reader = pipe_reader }
   | And (a, b) ->
-      let a_status =
-        eval a
-          {
-            ctx with
-            stdout_writer = Unix.dup ctx.stdout_writer;
-            stderr_writer = Unix.dup ctx.stderr_writer;
-            stdin_reader = Unix.dup ctx.stdin_reader;
-          }
-      in
-      if a_status = success_status then eval b ctx
-      else (
-        Unix.close ctx.stdout_writer;
-        Unix.close ctx.stderr_writer;
-        Unix.close ctx.stdin_reader;
-        a_status)
-  | Or (a, b) ->
-      let a_status =
-        eval a
-          {
-            ctx with
-            stdout_writer = Unix.dup ctx.stdout_writer;
-            stderr_writer = Unix.dup ctx.stderr_writer;
-            stdin_reader = Unix.dup ctx.stdin_reader;
-          }
-      in
-      if a_status = success_status then (
-        Unix.close ctx.stdout_writer;
-        Unix.close ctx.stderr_writer;
-        Unix.close ctx.stdin_reader;
-        a_status)
-      else eval b ctx
-  | Sequence (a, b) ->
-      let (_status : int) =
-        eval a
-          {
-            ctx with
-            stdout_writer = Unix.dup ctx.stdout_writer;
-            stderr_writer = Unix.dup ctx.stderr_writer;
-            stdin_reader = Unix.dup ctx.stdin_reader;
-          }
-      in
-      eval b ctx
-  | Write_out_to (str, cmd) ->
+    let a_status =
+      eval
+        a
+        { ctx with
+          stdout_writer = Unix.dup ctx.stdout_writer
+        ; stderr_writer = Unix.dup ctx.stderr_writer
+        ; stdin_reader = Unix.dup ctx.stdin_reader
+        }
+    in
+    if a_status = success_status
+    then eval b ctx
+    else (
       Unix.close ctx.stdout_writer;
-      let stdout_writer =
-        Unix.openfile str [ O_WRONLY; O_TRUNC; O_CREAT ] 0o644
-      in
-      eval cmd { ctx with stdout_writer }
-  | Append_out_to (str, cmd) ->
-      Unix.close ctx.stdout_writer;
-      let stdout_writer =
-        Unix.openfile str [ O_WRONLY; O_APPEND; O_CREAT ] 0o644
-      in
-      eval cmd { ctx with stdout_writer }
-  | Write_err_to (str, cmd) ->
-      let stderr_writer =
-        Unix.openfile str [ O_WRONLY; O_TRUNC; O_CREAT ] 0o644
-      in
-      eval cmd { ctx with stderr_writer }
-  | Append_err_to (str, cmd) ->
-      let stderr_writer =
-        Unix.openfile str [ O_WRONLY; O_APPEND; O_CREAT ] 0o644
-      in
-      eval cmd { ctx with stderr_writer }
-  | Read_in_from (str, cmd) ->
-      let stdin_reader = Unix.openfile str [ O_RDONLY ] 0 in
-      eval cmd { ctx with stdin_reader }
-  | Out_to_err cmd ->
-      Unix.close ctx.stdout_writer;
-      let stdout_writer = Unix.dup ctx.stderr_writer in
-      eval cmd { ctx with stdout_writer }
-  | Err_to_out cmd ->
       Unix.close ctx.stderr_writer;
-      let stderr_writer = Unix.dup ctx.stdout_writer in
-      eval cmd { ctx with stderr_writer }
+      Unix.close ctx.stdin_reader;
+      a_status)
+  | Or (a, b) ->
+    let a_status =
+      eval
+        a
+        { ctx with
+          stdout_writer = Unix.dup ctx.stdout_writer
+        ; stderr_writer = Unix.dup ctx.stderr_writer
+        ; stdin_reader = Unix.dup ctx.stdin_reader
+        }
+    in
+    if a_status = success_status
+    then (
+      Unix.close ctx.stdout_writer;
+      Unix.close ctx.stderr_writer;
+      Unix.close ctx.stdin_reader;
+      a_status)
+    else eval b ctx
+  | Sequence (a, b) ->
+    let (_status : int) =
+      eval
+        a
+        { ctx with
+          stdout_writer = Unix.dup ctx.stdout_writer
+        ; stderr_writer = Unix.dup ctx.stderr_writer
+        ; stdin_reader = Unix.dup ctx.stdin_reader
+        }
+    in
+    eval b ctx
+  | Write_out_to (str, cmd) ->
+    Unix.close ctx.stdout_writer;
+    let stdout_writer = Unix.openfile str [ O_WRONLY; O_TRUNC; O_CREAT ] 0o644 in
+    eval cmd { ctx with stdout_writer }
+  | Append_out_to (str, cmd) ->
+    Unix.close ctx.stdout_writer;
+    let stdout_writer = Unix.openfile str [ O_WRONLY; O_APPEND; O_CREAT ] 0o644 in
+    eval cmd { ctx with stdout_writer }
+  | Write_err_to (str, cmd) ->
+    let stderr_writer = Unix.openfile str [ O_WRONLY; O_TRUNC; O_CREAT ] 0o644 in
+    eval cmd { ctx with stderr_writer }
+  | Append_err_to (str, cmd) ->
+    let stderr_writer = Unix.openfile str [ O_WRONLY; O_APPEND; O_CREAT ] 0o644 in
+    eval cmd { ctx with stderr_writer }
+  | Read_in_from (str, cmd) ->
+    let stdin_reader = Unix.openfile str [ O_RDONLY ] 0 in
+    eval cmd { ctx with stdin_reader }
+  | Out_to_err cmd ->
+    Unix.close ctx.stdout_writer;
+    let stdout_writer = Unix.dup ctx.stderr_writer in
+    eval cmd { ctx with stdout_writer }
+  | Err_to_out cmd ->
+    Unix.close ctx.stderr_writer;
+    let stderr_writer = Unix.dup ctx.stdout_writer in
+    eval cmd { ctx with stderr_writer }
   | Filter_mapi f ->
-      filter_mapi ~f ctx;
-      0
+    filter_mapi ~f ctx;
+    0
+;;
 
 let process name args = Process (name, args)
-
 let ( |. ) a b = Pipe (a, b)
-
 let and_ a b = And (a, b)
-
 let or_ a b = Or (a, b)
-
 let sequence a b = Sequence (a, b)
 
 (* Redirection *)
 
 let write_stdout_to str cmd = Write_out_to (str, cmd)
-
 let append_stdout_to str cmd = Append_out_to (str, cmd)
-
 let write_stderr_to str cmd = Write_err_to (str, cmd)
-
 let append_stderr_to str cmd = Append_err_to (str, cmd)
-
 let read_stdin_from str cmd = Read_in_from (str, cmd)
 
 module Infix = struct
   let ( |. ) = ( |. )
-
   let ( &&. ) = and_
-
   let ( ||. ) = or_
-
   let ( ->. ) = sequence
-
   let ( > ) cmd str = write_stdout_to str cmd
-
   let ( >> ) cmd str = append_stdout_to str cmd
-
   let ( >! ) cmd str = write_stderr_to str cmd
-
   let ( >>! ) cmd str = append_stderr_to str cmd
-
   let ( < ) cmd str = read_stdin_from str cmd
-
   let ( <<< ) cmd s = Of_list [ s ] |. cmd
 end
 
 let stdout_to_stderr cmd = Out_to_err cmd
-
 let stderr_to_stdout cmd = Err_to_out cmd
 
 (* === Collection facilities === *)
 
 let status = Collect_status
-
 let stdout = Collect_stdout
-
 let stderr = Collect_stderr
-
 let stdout_and_stderr = Collect_stdout_stderr
-
 let stdout_and_status = Collect_stdout_status
-
 let stderr_and_status = Collect_stderr_status
-
 let everything = Collect_everything
 
 (* Take a file descriptor and read everything into a single string *)
@@ -402,134 +400,138 @@ let collect_into_string_sync fd =
   match String.chop_suffix out ~suffix:"\n" with
   | Some trimmed -> trimmed
   | None -> out
+;;
 
 (* Same thing but do it in another thread, returning an event which will contain
  * the string *)
 let collect_into_string_async fd =
   let chan = Event.new_channel () in
-  Thread.run (fun _ ->
-      collect_into_string_sync fd |> Event.send chan |> Event.sync);
+  Thread.run (fun _ -> collect_into_string_sync fd |> Event.send chan |> Event.sync);
   Event.receive chan
+;;
 
 (* Launch the command and collect expected channels *)
 let collect (type a) ?cwd ?env (what_to_collect : a what_to_collect) cmd : a =
-  let eval ?(stdout_writer = Unix.dup Unix.stdout)
-      ?(stderr_writer = Unix.dup Unix.stderr) () =
-    eval cmd
-      {
-        stdin_reader = Unix.dup Unix.stdin;
-        stdout_writer;
-        stderr_writer;
-        cwd;
-        env;
-      }
+  let eval
+        ?(stdout_writer = Unix.dup Unix.stdout)
+        ?(stderr_writer = Unix.dup Unix.stderr)
+        ()
+    =
+    eval
+      cmd
+      { stdin_reader = Unix.dup Unix.stdin; stdout_writer; stderr_writer; cwd; env }
   in
-
   (* Launch the command while collecting asynchronously the wanted outputs *)
   match what_to_collect with
   | Collect_status -> eval ()
   | Collect_stdout ->
-      let stdout_reader, stdout_writer = Unix.pipe () in
-      let stdout = collect_into_string_async stdout_reader in
-      let (_ : int) = eval ~stdout_writer () in
-      Event.sync stdout
+    let stdout_reader, stdout_writer = Unix.pipe () in
+    let stdout = collect_into_string_async stdout_reader in
+    let (_ : int) = eval ~stdout_writer () in
+    Event.sync stdout
   | Collect_stderr ->
-      let stderr_reader, stderr_writer = Unix.pipe () in
-      let stderr = collect_into_string_async stderr_reader in
-      let (_ : int) = eval ~stderr_writer () in
-      Event.sync stderr
+    let stderr_reader, stderr_writer = Unix.pipe () in
+    let stderr = collect_into_string_async stderr_reader in
+    let (_ : int) = eval ~stderr_writer () in
+    Event.sync stderr
   | Collect_stdout_status ->
-      let stdout_reader, stdout_writer = Unix.pipe () in
-      let stdout = collect_into_string_async stdout_reader in
-      let status = eval ~stdout_writer () in
-      (Event.sync stdout, status)
+    let stdout_reader, stdout_writer = Unix.pipe () in
+    let stdout = collect_into_string_async stdout_reader in
+    let status = eval ~stdout_writer () in
+    Event.sync stdout, status
   | Collect_stderr_status ->
-      let stderr_reader, stderr_writer = Unix.pipe () in
-      let stderr = collect_into_string_async stderr_reader in
-      let status = eval ~stderr_writer () in
-      (Event.sync stderr, status)
+    let stderr_reader, stderr_writer = Unix.pipe () in
+    let stderr = collect_into_string_async stderr_reader in
+    let status = eval ~stderr_writer () in
+    Event.sync stderr, status
   | Collect_stdout_stderr ->
-      let stdout_reader, stdout_writer = Unix.pipe () in
-      let stderr_reader, stderr_writer = Unix.pipe () in
-      let stdout = collect_into_string_async stdout_reader in
-      let stderr = collect_into_string_async stderr_reader in
-      let (_ : int) = eval ~stdout_writer ~stderr_writer () in
-      (Event.sync stdout, Event.sync stderr)
+    let stdout_reader, stdout_writer = Unix.pipe () in
+    let stderr_reader, stderr_writer = Unix.pipe () in
+    let stdout = collect_into_string_async stdout_reader in
+    let stderr = collect_into_string_async stderr_reader in
+    let (_ : int) = eval ~stdout_writer ~stderr_writer () in
+    Event.sync stdout, Event.sync stderr
   | Collect_everything ->
-      let stdout_reader, stdout_writer = Unix.pipe () in
-      let stderr_reader, stderr_writer = Unix.pipe () in
-      let stdout = collect_into_string_async stdout_reader in
-      let stderr = collect_into_string_async stderr_reader in
-      let status = eval ~stdout_writer ~stderr_writer () in
-      { status; stdout = Event.sync stdout; stderr = Event.sync stderr }
+    let stdout_reader, stdout_writer = Unix.pipe () in
+    let stderr_reader, stderr_writer = Unix.pipe () in
+    let stdout = collect_into_string_async stdout_reader in
+    let stderr = collect_into_string_async stderr_reader in
+    let status = eval ~stdout_writer ~stderr_writer () in
+    { status; stdout = Event.sync stdout; stderr = Event.sync stderr }
+;;
 
 let lines = String.split_lines
-
 let filter_mapi_lines ~f = Filter_mapi f
-
 let filter_map_lines ~f = filter_mapi_lines ~f:(fun a _ -> f a)
-
-let filteri_lines ~f =
-  filter_mapi_lines ~f:(fun a i -> if f a i then Some a else None)
-
+let filteri_lines ~f = filter_mapi_lines ~f:(fun a i -> if f a i then Some a else None)
 let filter_lines ~f = filteri_lines ~f:(fun a _ -> f a)
-
 let mapi_lines ~f = filter_mapi_lines ~f:(fun a i -> Some (f a i))
-
 let map_lines ~f = mapi_lines ~f:(fun a _ -> f a)
 
 let run' ?cwd ?env cmd =
   Stdlib.flush_all ();
-  eval cmd
-    {
-      stdin_reader = Unix.dup Unix.stdin;
-      stdout_writer = Unix.dup Unix.stdout;
-      stderr_writer = Unix.dup Unix.stderr;
-      cwd;
-      env;
+  eval
+    cmd
+    { stdin_reader = Unix.dup Unix.stdin
+    ; stdout_writer = Unix.dup Unix.stdout
+    ; stderr_writer = Unix.dup Unix.stderr
+    ; cwd
+    ; env
     }
+;;
 
 let run_in_background ?cwd ?env cmd =
   let process = State.new_background_process () in
   Thread.run (fun () ->
-      let (_status : int) = run' ?cwd ?env cmd in
-      Mutex.with_lock process.mutex (fun () ->
-          process.result <- Some ();
-          Condition.broadcast process.condition));
+    let (_status : int) = run' ?cwd ?env cmd in
+    Mutex.with_lock process.mutex (fun () ->
+      process.result <- Some ();
+      Condition.broadcast process.condition));
   process
+;;
 
 let collect_in_background ?cwd ?env what_to_collect cmd =
   let process = State.new_background_process () in
   Thread.run (fun () ->
-      let result = collect ?cwd ?env what_to_collect cmd in
-      Mutex.with_lock process.mutex (fun () ->
-          process.result <- Some result;
-          Condition.broadcast process.condition));
+    let result = collect ?cwd ?env what_to_collect cmd in
+    Mutex.with_lock process.mutex (fun () ->
+      process.result <- Some result;
+      Condition.broadcast process.condition));
   process
+;;
 
 let wait (process : 'a Background_process.t) =
   Mutex.with_lock process.mutex (fun () ->
-      match process.result with
-      | Some a -> a
-      | None ->
-          Condition.wait process.condition process.mutex;
-          Option.value_exn process.result)
+    match process.result with
+    | Some a -> a
+    | None ->
+      Condition.wait process.condition process.mutex;
+      Option.value_exn process.result)
+;;
 
 let wait_all () =
   State.all_background_processes ()
   |> List.iter ~f:(function Background_process.T process ->
-         let _ = wait process in
-         ())
+      let _ = wait process in
+      ())
+;;
 
 let run ?cwd ?env cmd =
   let (_status : int) = run' ?cwd ?env cmd in
   ()
+;;
 
 (* === Common Unix commands === *)
 let ls s = process "ls" [ s ]
 
-let find ?(include_starting_dir = false) ?(ignore_hidden = false)
-    ?(kind : [ `Directories | `Files ] option) ?name ?depth directory =
+let find
+      ?(include_starting_dir = false)
+      ?(ignore_hidden = false)
+      ?(kind : [ `Directories | `Files ] option)
+      ?name
+      ?depth
+      directory
+  =
   let args = [ directory ] in
   let args =
     match kind with
@@ -539,67 +541,56 @@ let find ?(include_starting_dir = false) ?(ignore_hidden = false)
   in
   let args =
     args
-    @ ([
-         Option.map depth ~f:(fun depth -> [ "-maxdepth"; Int.to_string depth ]);
-         Option.map name ~f:(fun name -> [ "-name"; name ]);
-         (if ignore_hidden then Some [ "-not"; "-path"; "*/\\.*" ] else None);
-         (if include_starting_dir then None
-         else Some [ "-not"; "-path"; directory ]);
+    @ ([ Option.map depth ~f:(fun depth -> [ "-maxdepth"; Int.to_string depth ])
+       ; Option.map name ~f:(fun name -> [ "-name"; name ])
+       ; (if ignore_hidden then Some [ "-not"; "-path"; "*/\\.*" ] else None)
+       ; (if include_starting_dir then None else Some [ "-not"; "-path"; directory ])
        ]
-      |> List.filter_opt |> List.concat)
+       |> List.filter_opt
+       |> List.concat)
   in
   process "find" args
+;;
 
 let sh s = process "sh" [ "-c"; s ]
-
 let rg ?in_ regex = process "rg" (List.filter_opt [ Some regex; in_ ])
-
-let rg_v ?in_ regex =
-  process "rg" ([ "-v" ] @ List.filter_opt [ Some regex; in_ ])
-
+let rg_v ?in_ regex = process "rg" ([ "-v" ] @ List.filter_opt [ Some regex; in_ ])
 let grep ?in_ regex = process "grep" (List.filter_opt [ Some regex; in_ ])
-
 let cat file = process "cat" [ file ]
-
 let less = process "less" []
-
 let mkdir dir = process "mkdir" [ dir ]
-
 let mkdir_p dir = process "mkdir" [ "-p"; dir ]
-
 let sort = process "sort" []
-
 let uniq = process "uniq" []
-
 let shuf = process "shuf" []
 
 let head ?file n =
   process "head" (List.filter_opt [ Some "-n"; Some (Int.to_string n); file ])
+;;
 
 let tail ?file n =
   process "tail" (List.filter_opt [ Some "-n"; Some (Int.to_string n); file ])
+;;
 
 let tail_f file = process "tail" [ "-f"; file ]
-
 let echo s = process "echo" [ s ]
 
 let cut' ?complement ?(d = ' ') fs =
   process
-    (match resolve_in_path "gcut" with Some _ -> "gcut" | None -> "cut")
-    ([
-       "-f";
-       List.map fs ~f:Int.to_string |> String.concat ~sep:",";
-       "-d";
-       Char.to_string d;
+    (match resolve_in_path "gcut" with
+     | Some _ -> "gcut"
+     | None -> "cut")
+    ([ "-f"
+     ; List.map fs ~f:Int.to_string |> String.concat ~sep:","
+     ; "-d"
+     ; Char.to_string d
      ]
-    @ List.filter_opt [ Option.map complement ~f:(fun () -> "--complement") ])
+     @ List.filter_opt [ Option.map complement ~f:(fun () -> "--complement") ])
+;;
 
 let cut ?d f = cut' ?d [ f ]
-
 let cp src dst = process "cp" [ src; dst ]
-
 let cp_r src dst = process "cp" [ "-r"; src; dst ]
-
 let mv src dst = process "mv" [ src; dst ]
 
 (* TODO: Refactor to not spawn a process. Potentially applicable to:
@@ -621,34 +612,35 @@ let pwd = process "pwd" []
 
 let sed ?(g = true) pattern replace =
   process "sed" [ ("s/" ^ pattern ^ "/" ^ replace ^ if g then "/g" else "/") ]
+;;
 
 let tr from_ to_ = process "tr" [ from_; to_ ]
-
 let tr_d chars = process "tr" [ "-d"; chars ]
 
 (* === Misc === *)
 
 let of_list l = Of_list l
-
 let devnull = "/dev/null"
 
 let fzf ?cwd ?env cmd =
-  let stdout, status =
-    cmd |. process "fzf" [] |> collect ?cwd ?env stdout_and_status
-  in
+  let stdout, status = cmd |. process "fzf" [] |> collect ?cwd ?env stdout_and_status in
   if status = 0 then Some stdout else None
+;;
 
 (* === Signals === *)
 let terminate_child_processes () =
   process "pgrep" [ "-P"; Int.to_string State.pid ]
-  |> collect stdout |> lines |> List.map ~f:Int.of_string
+  |> collect stdout
+  |> lines
+  |> List.map ~f:Int.of_string
   |> List.iter ~f:(fun pid ->
-         try Unix.kill pid Sys.sigterm
-         with Unix.Unix_error (Unix.ESRCH, _, _) ->
-           (* [Unix.ERSCH] is raised when a process cannot be found, which
-            * means that the child has already terminated, so it should
-            * be safe to ignore this exception. *)
-           ())
+    try Unix.kill pid Sys.sigterm with
+    | Unix.Unix_error (Unix.ESRCH, _, _) ->
+      (* [Unix.ERSCH] is raised when a process cannot be found, which
+       * means that the child has already terminated, so it should
+       * be safe to ignore this exception. *)
+      ())
+;;
 
 let () = Stdlib.at_exit terminate_child_processes
 
@@ -663,102 +655,133 @@ let%test_module _ =
     let%expect_test _ =
       echo "hi\n" |> print;
       [%expect "hi"]
+    ;;
 
     let%expect_test _ =
-      echo {|
+      echo
+        {|
 hi
 you
 there
 hi
-|} |. sort |. uniq |. rg "h" |. sed "^" "<> "
+|}
+      |. sort
+      |. uniq
+      |. rg "h"
+      |. sed "^" "<> "
       |> print;
-      [%expect {|
+      [%expect
+        {|
     <> hi
     <> there |}]
+    ;;
 
     let%expect_test _ =
-      let text = {|
+      let text =
+        {|
 0 hi,2 a
 1 you,3 b
-|} in
+|}
+      in
       echo text |. cut 1 |> print;
-      [%expect {|
+      [%expect
+        {|
         0
         1 |}];
       echo text |. cut ~d:',' 2 |> print;
-      [%expect {|
+      [%expect
+        {|
         2 a
         3 b |}];
       echo text |. cut' [ 1; 3 ] |> print;
-      [%expect {|
+      [%expect
+        {|
         0 a
         1 b |}];
       (* complement relies on gnu cut *)
       echo text |. cut' ~complement:() [ 1; 3 ] |> print;
-      [%expect {|
+      [%expect
+        {|
         hi,2
         you,3 |}];
       echo text
       |. map_lines ~f:(fun line ->
-             String.split line ~on:' '
-             |> List.filter ~f:(fun x -> String.length x = 1)
-             |> List.rev |> String.concat ~sep:"--")
+        String.split line ~on:' '
+        |> List.filter ~f:(fun x -> String.length x = 1)
+        |> List.rev
+        |> String.concat ~sep:"--")
       |> print;
-      [%expect {|
+      [%expect
+        {|
         a--0
         b--1 |}]
+    ;;
 
     let%expect_test _ =
       process "false" [] &&. echo "test" |> print;
       [%expect ""]
+    ;;
 
     let%expect_test _ =
       process "true" [] &&. echo "test" |> print;
       [%expect "test"]
+    ;;
 
     let%expect_test _ =
       process "false" [] ||. echo "test" |> print;
       [%expect "test"]
+    ;;
 
     let%expect_test _ =
       process "true" [] ||. echo "test" |> print;
       [%expect ""]
+    ;;
 
     let%expect_test _ =
       process "false" [] ||. process "true" [] &&. echo "test" |> print;
       [%expect "test"]
+    ;;
 
     let%expect_test _ =
       process "true" [] &&. process "false" [] ||. echo "test" |> print;
       [%expect "test"]
+    ;;
 
     let%expect_test _ =
       process "false" [] ||. process "false" [] &&. echo "test" |> print;
       [%expect ""]
+    ;;
 
     let%expect_test _ =
       process "true" [] &&. process "false" [] ||. echo "test" |> print;
       [%expect "test"]
+    ;;
 
     let%expect_test _ =
       echo "test" |. process "true" [] ->. cat "-" |> print;
       [%expect "test"]
+    ;;
 
     let%expect_test _ =
       echo "test" |. process "false" [] ->. cat "-" |> print;
       [%expect "test"]
+    ;;
 
     let%expect_test "find" =
       find "." ~ignore_hidden:true ~kind:`Files ~name:"*.ml"
-      |. rg_v {|\.pp\.|} |. sort |> print;
-      [%expect {|
+      |. rg_v {|\.pp\.|}
+      |. sort
+      |> print;
+      [%expect
+        {|
         ./feather.ml |}]
+    ;;
 
     let%expect_test "waitpid should retry on EINTR" =
-      process "kill"
-        (List.map ~f:Int.to_string [ Stdlib.Sys.sigurg; Unix.getpid () ])
+      process "kill" (List.map ~f:Int.to_string [ Stdlib.Sys.sigurg; Unix.getpid () ])
       |> print;
       [%expect ""]
+    ;;
 
     let%expect_test "redirection/collection" =
       let print cmd =
@@ -766,7 +789,8 @@ hi
         printf "== Stdout ==\n%s\n== Stderr ==\n%s\n" stdout stderr
       in
       echo "test" |> print;
-      [%expect {|
+      [%expect
+        {|
         == Stdout ==
         test
         == Stderr == |}];
@@ -777,8 +801,7 @@ hi
         test2
         == Stderr ==
         test1 |}];
-      echo "test1" |> stdout_to_stderr &&. echo "test2" |> stderr_to_stdout
-      |> print;
+      echo "test1" |> stdout_to_stderr &&. echo "test2" |> stderr_to_stdout |> print;
       [%expect
         {|
         == Stdout ==
@@ -786,29 +809,36 @@ hi
         test2
         == Stderr ==
         |}]
+    ;;
 
     let%expect_test "large collection" =
       let to_run () =
         ignore
-          (process "dd"
-             [ "if=/dev/zero"; "of=/dev/stdout"; "bs=1000000"; "count=1" ]
-          |> stderr_to_stdout |> collect stdout);
+          (process "dd" [ "if=/dev/zero"; "of=/dev/stdout"; "bs=1000000"; "count=1" ]
+           |> stderr_to_stdout
+           |> collect stdout);
         printf "collection done!\n"
       in
       Thread.run to_run;
       Thread.delay 2.0;
-      [%expect {|
+      [%expect
+        {|
         collection done!
     |}]
+    ;;
 
     let%expect_test "of_list" =
       of_list [ "one"; "two"; "three" ] |. sort |> print;
-      [%expect {|
+      [%expect
+        {|
         one
         three
         two |}]
+    ;;
 
     let%expect_test "here-string" =
       process "cat" [] <<< "hello" |> print;
       [%expect {| hello |}]
+    ;;
   end)
+;;

--- a/src/feather.mli
+++ b/src/feather.mli
@@ -1,240 +1,216 @@
-(** {2 {b Creating and combining Feather commands } } *)
+(** {2 {b Creating and combining Feather commands}} *)
 
 type cmd
 
+(** [process] constructs a new [cmd] that can be run with [run] or [collect] *)
 val process : string -> string list -> cmd
-(** [process] constructs a new [cmd] that can be run with [run] or [collect]  *)
 
-val ( |. ) : cmd -> cmd -> cmd
 (** [ |. ] is Feather's version of a "|" in bash; pipe the first process's
     stdout to the next's stdin. *)
+val ( |. ) : cmd -> cmd -> cmd
 
-val and_ : cmd -> cmd -> cmd
 (** [ and_ ] is feather's version of a "&&" in bash. See Infix module for more. *)
+val and_ : cmd -> cmd -> cmd
 
-val or_ : cmd -> cmd -> cmd
 (** [ or_ ] is feather's version of a "||" in bash. See Infix module for more. *)
+val or_ : cmd -> cmd -> cmd
 
-val sequence : cmd -> cmd -> cmd
 (** [ sequence ] is feather's version of a ";" in bash. See Infix module for more. *)
+val sequence : cmd -> cmd -> cmd
 
-(** {2 {b Running Feather commands } } *)
+(** {2 {b Running Feather commands}} *)
 
-val run : ?cwd:string -> ?env:(string * string) list -> cmd -> unit
 (** Run a command without collecting anything *)
+val run : ?cwd:string -> ?env:(string * string) list -> cmd -> unit
 
-type 'a what_to_collect
 (** The type that determines what should be returned by {!collect} *)
+type 'a what_to_collect
 
 (** Various collection possibilities, to be used with {!collect} *)
 
 val stdout : string what_to_collect
-
 val stderr : string what_to_collect
-
 val status : int what_to_collect
-
 val stdout_and_stderr : (string * string) what_to_collect
-
 val stdout_and_status : (string * int) what_to_collect
-
 val stderr_and_status : (string * int) what_to_collect
 
-type everything = { stdout : string; stderr : string; status : int }
+type everything =
+  { stdout : string
+  ; stderr : string
+  ; status : int
+  }
 
 val everything : everything what_to_collect
 
-val collect :
-  ?cwd:string -> ?env:(string * string) list -> 'a what_to_collect -> cmd -> 'a
 (** [ collect col cmd ] runs [cmd], collecting the outputs specified by [col]
     along the way and returning them. The return type depends on what is
     collected. *)
+val collect
+  :  ?cwd:string
+  -> ?env:(string * string) list
+  -> 'a what_to_collect
+  -> cmd
+  -> 'a
 
 type 'a background_process
 
-val run_in_background :
-  ?cwd:string -> ?env:(string * string) list -> cmd -> unit background_process
+val run_in_background
+  :  ?cwd:string
+  -> ?env:(string * string) list
+  -> cmd
+  -> unit background_process
 
-val collect_in_background :
-  ?cwd:string ->
-  ?env:(string * string) list ->
-  'a what_to_collect ->
-  cmd ->
-  'a background_process
 (** [collect_in_background] and [run_in_background] run the command in a thread.
 
     Use [wait] to wait for the process to finish (and retreive whatever you collected). *)
+val collect_in_background
+  :  ?cwd:string
+  -> ?env:(string * string) list
+  -> 'a what_to_collect
+  -> cmd
+  -> 'a background_process
 
-val wait : 'a background_process -> 'a
 (** [wait] for the result of [run_in_background] or [collect_in_background]. *)
+val wait : 'a background_process -> 'a
 
-val wait_all : unit -> unit
 (** Wait for all processes started in the background. *)
+val wait_all : unit -> unit
 
-(** {2 {b Commands to insert OCaml within a Feather pipeline } } *)
+(** {2 {b Commands to insert OCaml within a Feather pipeline}} *)
 
-val map_lines : f:(string -> string) -> cmd
 (** [map_lines] within a sequence of pipes will be run with a thread.
     Same goes for [filter_lines], [mapi_lines], etc. *)
+val map_lines : f:(string -> string) -> cmd
 
 val filter_lines : f:(string -> bool) -> cmd
-
 val mapi_lines : f:(string -> int -> string) -> cmd
-
 val filteri_lines : f:(string -> int -> bool) -> cmd
-
 val filter_map_lines : f:(string -> string option) -> cmd
-
 val filter_mapi_lines : f:(string -> int -> string option) -> cmd
 
-(** {2 {b File redirection } } *)
+(** {2 {b File redirection}} *)
 
 val write_stdout_to : string -> cmd -> cmd
-
 val append_stdout_to : string -> cmd -> cmd
-
 val write_stderr_to : string -> cmd -> cmd
-
 val append_stderr_to : string -> cmd -> cmd
-
 val read_stdin_from : string -> cmd -> cmd
-
 val stdout_to_stderr : cmd -> cmd
 
-val stderr_to_stdout : cmd -> cmd
 (** [stdout_to_stderr] and [stderr_to_stdout] are NOT composable!
     Think of these functions as each creating a new command with the given redirection.
 
     Applying both will result in no output to either stdout or stderr.
     [flip_stdout_and_stderr] should be easy to write if anyone should need it. *)
+val stderr_to_stdout : cmd -> cmd
 
 module Infix : sig
-  val ( |. ) : cmd -> cmd -> cmd
   (** Same as the top-level [ |. ] pipe operator *)
+  val ( |. ) : cmd -> cmd -> cmd
 
-  val ( > ) : cmd -> string -> cmd
   (** Redirect Stdout *)
+  val ( > ) : cmd -> string -> cmd
 
   val ( >> ) : cmd -> string -> cmd
 
-  val ( >! ) : cmd -> string -> cmd
   (** Redirect Stderr *)
+  val ( >! ) : cmd -> string -> cmd
 
   val ( >>! ) : cmd -> string -> cmd
 
-  val ( < ) : cmd -> string -> cmd
   (** Read file from stdin *)
+  val ( < ) : cmd -> string -> cmd
 
-  val ( &&. ) : cmd -> cmd -> cmd
   (** Same as [and_] *)
+  val ( &&. ) : cmd -> cmd -> cmd
 
-  val ( ||. ) : cmd -> cmd -> cmd
   (** Same as [or_] *)
+  val ( ||. ) : cmd -> cmd -> cmd
 
-  val ( ->. ) : cmd -> cmd -> cmd
   (** Same as [sequence]
 
       [->.] binds more tightly than [|.] so parentheses should be used when
-      chaining the two.
-  *)
+      chaining the two. *)
+  val ( ->. ) : cmd -> cmd -> cmd
 
-  val ( <<< ) : cmd -> string -> cmd
   (** Here-string: feed a string directly to a command's stdin without
       spawning a subprocess. Analogous to bash's [<<<]. *)
+  val ( <<< ) : cmd -> string -> cmd
 end
 
-(** {2 {b Built-in commands } } *)
+(** {2 {b Built-in commands}} *)
 
 val ls : string -> cmd
 
-val find :
-  ?include_starting_dir:bool ->
-  ?ignore_hidden:bool ->
-  ?kind:[ `Files | `Directories ] ->
-  ?name:string ->
-  ?depth:int ->
-  string ->
-  cmd
 (** [find] lists files and/or directories, optionally filtering by name.
 
     [?depth]: The maximum search depth, defaults to infinity.
 
     [?include_starting_dir]: whether to include the starting directory passed
     into [find]. Defaults to [false], notably different than the unix find
-    utility.
-*)
+    utility. *)
+val find
+  :  ?include_starting_dir:bool
+  -> ?ignore_hidden:bool
+  -> ?kind:[ `Files | `Directories ]
+  -> ?name:string
+  -> ?depth:int
+  -> string
+  -> cmd
 
 val sh : string -> cmd
 
-val rg : ?in_:string -> string -> cmd
 (** [in_] is the directory that should be rg'd: rg <search> <in>. Without it, it'll filter
     stdin, just rg <search> *)
+val rg : ?in_:string -> string -> cmd
 
 val rg_v : ?in_:string -> string -> cmd
-
 val grep : ?in_:string -> string -> cmd
-
 val cat : string -> cmd
-
 val less : cmd
-
 val mkdir : string -> cmd
-
 val mkdir_p : string -> cmd
-
 val sort : cmd
-
 val uniq : cmd
-
 val shuf : cmd
-
 val head : ?file:string -> int -> cmd
-
 val tail : ?file:string -> int -> cmd
-
 val tail_f : string -> cmd
-
 val echo : string -> cmd
-
 val cut' : ?complement:unit -> ?d:char -> int list -> cmd
-
 val cut : ?d:char (** defaults to a space *) -> int -> cmd
-
 val cp : string -> string -> cmd
-
 val cp_r : string -> string -> cmd
-
 val mv : string -> string -> cmd
-
 val pwd : cmd
 
-val sed :
-  ?g:bool (** defaults to TRUE *) ->
-  string (** pattern *) ->
-  string (** replacement *) ->
-  cmd
+val sed
+  :  ?g:bool (** defaults to TRUE *)
+  -> string (** pattern *)
+  -> string (** replacement *)
+  -> cmd
 
 val tr : string -> string -> cmd
-
 val tr_d : string -> cmd
 
-(** {2 {b Misc } } *)
+(** {2 {b Misc}} *)
 
-val of_list : string list -> cmd
 (** [of_list] emulates a Feather.cmd, each item in the list becomes a line on
     stdout. *)
+val of_list : string list -> cmd
 
-val lines : string -> string list
 (** [lines] splits a string into the list of its lines *)
+val lines : string -> string list
 
-val devnull : string
 (** [devnull] is easier to type than "/dev/null" *)
+val devnull : string
 
-val fzf : ?cwd:string -> ?env:(string * string) list -> cmd -> string option
 (** [fzf] runs the command, and fuzzy finds the stdout.
-   Returns [None] if no item was chosen, [Some str] otherwise
+    Returns [None] if no item was chosen, [Some str] otherwise
 
-   Note that [fzf] is a way to to run a [cmd] and does not in itself return a
-   [cmd]. *)
+    Note that [fzf] is a way to to run a [cmd] and does not in itself return a
+    [cmd]. *)
+val fzf : ?cwd:string -> ?env:(string * string) list -> cmd -> string option
 
 val debug : bool ref


### PR DESCRIPTION
The project already enables ocamlformat but with an empty config. I am not exactly sure what are all the default picked when using an empty config, or if the defaults are stable across ocamlformat upgrades.

In this PR we add some element of configuration explicitly.

See #38 

### TODOs

- [ ] Populating the revision that apply the fmt into a `.git-blame-ignore-revs` is better done once the PR is merged into master, as follow up work, as often SHA can change in the process of onboarding and merging the PR
- [ ] This PR currently stacks on top of #39