### PR TITLE
Ocamlformat conventional

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,3 @@
+version=0.29.0
+profile=conventional
+parse-docstrings=true

--- a/async/feather_async.ml
+++ b/async/feather_async.ml
@@ -2,11 +2,8 @@ open! Base
 open! Async
 
 let run_in_background = `Use_don't_wait_for
-
 let collect_in_background = `Use_don't_wait_for
-
 let run ?cwd ?env cmd = In_thread.run (fun () -> Feather.run ?cwd ?env cmd)
-
 let fzf ?cwd ?env cmd = In_thread.run (fun () -> Feather.fzf ?cwd ?env cmd)
 
 let collect ?cwd ?env what_to_collect cmd =

--- a/async/feather_async.mli
+++ b/async/feather_async.mli
@@ -1,6 +1,7 @@
 open Async
 
-(** Feather_async provides functions to run Feather cmd's within an Async context. *)
+(** Feather_async provides functions to run Feather cmd's within an Async
+    context. *)
 
 val run :
   ?cwd:string -> ?env:(string * string) list -> Feather.cmd -> unit Deferred.t
@@ -19,17 +20,17 @@ val fzf :
   string option Deferred.t
 
 val run_in_background : [ `Use_don't_wait_for ]
-  [@@alert
-    run_bg
-      {|  [Feather_async.run_in_background] intentionally shadows [Feather.run_in_background].
+[@@alert
+  run_bg
+    {|  [Feather_async.run_in_background] intentionally shadows [Feather.run_in_background].
 
           When using [Feather_async], use [Async.don't_wait_for] to run things
           asynchronously. |}]
 
 val collect_in_background : [ `Use_don't_wait_for ]
-  [@@alert
-    run_bg
-      {|  [Feather_async.collect_in_background] intentionally shadows [Feather.collect_in_background].
+[@@alert
+  run_bg
+    {|  [Feather_async.collect_in_background] intentionally shadows [Feather.collect_in_background].
 
           When using [Feather_async], use [Async.don't_wait_for] to run things
           asynchronously. |}]

--- a/example/example.ml
+++ b/example/example.ml
@@ -32,19 +32,15 @@ let __ () =
   let module Time = Time_float_unix in
   echo "count hour" |> run;
   echo "----- ----" |> run;
-  process "ls" [ "-lah" ]
-  |. sed "  *" " "
-  |. cut' [ 8 ]
+  process "ls" [ "-lah" ] |. sed "  *" " " |. cut' [ 8 ]
   |. filter_lines ~f:(fun line -> String.( <> ) line "")
   |. map_lines ~f:(fun line ->
-         Time.Ofday.of_string line |> Time.Ofday.to_span_since_start_of_day
-         |> Time.Span.to_hr |> Float.to_int
-         |> function
-         | n when n > 12 -> Int.to_string (n - 12) ^ " PM"
-         | n -> Int.to_string n ^ " AM")
-  |. process "sort" [ "-n" ]
-  |. process "uniq" [ "-c" ]
-  |> run
+      Time.Ofday.of_string line |> Time.Ofday.to_span_since_start_of_day
+      |> Time.Span.to_hr |> Float.to_int
+      |> function
+      | n when n > 12 -> Int.to_string (n - 12) ^ " PM"
+      | n -> Int.to_string n ^ " AM")
+  |. process "sort" [ "-n" ] |. process "uniq" [ "-c" ] |> run
 
 let __ () =
   let stderr, status =

--- a/src/feather.mli
+++ b/src/feather.mli
@@ -1,24 +1,27 @@
-(** {2 {b Creating and combining Feather commands } } *)
+(** {2 {b Creating and combining Feather commands}} *)
 
 type cmd
 
 val process : string -> string list -> cmd
-(** [process] constructs a new [cmd] that can be run with [run] or [collect]  *)
+(** [process] constructs a new [cmd] that can be run with [run] or [collect] *)
 
 val ( |. ) : cmd -> cmd -> cmd
 (** [ |. ] is Feather's version of a "|" in bash; pipe the first process's
     stdout to the next's stdin. *)
 
 val and_ : cmd -> cmd -> cmd
-(** [ and_ ] is feather's version of a "&&" in bash. See Infix module for more. *)
+(** [ and_ ] is feather's version of a "&&" in bash. See Infix module for more.
+*)
 
 val or_ : cmd -> cmd -> cmd
-(** [ or_ ] is feather's version of a "||" in bash. See Infix module for more. *)
+(** [ or_ ] is feather's version of a "||" in bash. See Infix module for more.
+*)
 
 val sequence : cmd -> cmd -> cmd
-(** [ sequence ] is feather's version of a ";" in bash. See Infix module for more. *)
+(** [ sequence ] is feather's version of a ";" in bash. See Infix module for
+    more. *)
 
-(** {2 {b Running Feather commands } } *)
+(** {2 {b Running Feather commands}} *)
 
 val run : ?cwd:string -> ?env:(string * string) list -> cmd -> unit
 (** Run a command without collecting anything *)
@@ -29,15 +32,10 @@ type 'a what_to_collect
 (** Various collection possibilities, to be used with {!collect} *)
 
 val stdout : string what_to_collect
-
 val stderr : string what_to_collect
-
 val status : int what_to_collect
-
 val stdout_and_stderr : (string * string) what_to_collect
-
 val stdout_and_status : (string * int) what_to_collect
-
 val stderr_and_status : (string * int) what_to_collect
 
 type everything = { stdout : string; stderr : string; status : int }
@@ -63,7 +61,8 @@ val collect_in_background :
   'a background_process
 (** [collect_in_background] and [run_in_background] run the command in a thread.
 
-    Use [wait] to wait for the process to finish (and retreive whatever you collected). *)
+    Use [wait] to wait for the process to finish (and retreive whatever you
+    collected). *)
 
 val wait : 'a background_process -> 'a
 (** [wait] for the result of [run_in_background] or [collect_in_background]. *)
@@ -71,42 +70,34 @@ val wait : 'a background_process -> 'a
 val wait_all : unit -> unit
 (** Wait for all processes started in the background. *)
 
-(** {2 {b Commands to insert OCaml within a Feather pipeline } } *)
+(** {2 {b Commands to insert OCaml within a Feather pipeline}} *)
 
 val map_lines : f:(string -> string) -> cmd
-(** [map_lines] within a sequence of pipes will be run with a thread.
-    Same goes for [filter_lines], [mapi_lines], etc. *)
+(** [map_lines] within a sequence of pipes will be run with a thread. Same goes
+    for [filter_lines], [mapi_lines], etc. *)
 
 val filter_lines : f:(string -> bool) -> cmd
-
 val mapi_lines : f:(string -> int -> string) -> cmd
-
 val filteri_lines : f:(string -> int -> bool) -> cmd
-
 val filter_map_lines : f:(string -> string option) -> cmd
-
 val filter_mapi_lines : f:(string -> int -> string option) -> cmd
 
-(** {2 {b File redirection } } *)
+(** {2 {b File redirection}} *)
 
 val write_stdout_to : string -> cmd -> cmd
-
 val append_stdout_to : string -> cmd -> cmd
-
 val write_stderr_to : string -> cmd -> cmd
-
 val append_stderr_to : string -> cmd -> cmd
-
 val read_stdin_from : string -> cmd -> cmd
-
 val stdout_to_stderr : cmd -> cmd
 
 val stderr_to_stdout : cmd -> cmd
-(** [stdout_to_stderr] and [stderr_to_stdout] are NOT composable!
-    Think of these functions as each creating a new command with the given redirection.
+(** [stdout_to_stderr] and [stderr_to_stdout] are NOT composable! Think of these
+    functions as each creating a new command with the given redirection.
 
     Applying both will result in no output to either stdout or stderr.
-    [flip_stdout_and_stderr] should be easy to write if anyone should need it. *)
+    [flip_stdout_and_stderr] should be easy to write if anyone should need it.
+*)
 
 module Infix : sig
   val ( |. ) : cmd -> cmd -> cmd
@@ -135,15 +126,14 @@ module Infix : sig
   (** Same as [sequence]
 
       [->.] binds more tightly than [|.] so parentheses should be used when
-      chaining the two.
-  *)
+      chaining the two. *)
 
   val ( <<< ) : cmd -> string -> cmd
-  (** Here-string: feed a string directly to a command's stdin without
-      spawning a subprocess. Analogous to bash's [<<<]. *)
+  (** Here-string: feed a string directly to a command's stdin without spawning
+      a subprocess. Analogous to bash's [<<<]. *)
 end
 
-(** {2 {b Built-in commands } } *)
+(** {2 {b Built-in commands}} *)
 
 val ls : string -> cmd
 
@@ -161,51 +151,32 @@ val find :
 
     [?include_starting_dir]: whether to include the starting directory passed
     into [find]. Defaults to [false], notably different than the unix find
-    utility.
-*)
+    utility. *)
 
 val sh : string -> cmd
 
 val rg : ?in_:string -> string -> cmd
-(** [in_] is the directory that should be rg'd: rg <search> <in>. Without it, it'll filter
-    stdin, just rg <search> *)
+(** [in_] is the directory that should be rg'd: rg <search> <in>. Without it,
+    it'll filter stdin, just rg <search> *)
 
 val rg_v : ?in_:string -> string -> cmd
-
 val grep : ?in_:string -> string -> cmd
-
 val cat : string -> cmd
-
 val less : cmd
-
 val mkdir : string -> cmd
-
 val mkdir_p : string -> cmd
-
 val sort : cmd
-
 val uniq : cmd
-
 val shuf : cmd
-
 val head : ?file:string -> int -> cmd
-
 val tail : ?file:string -> int -> cmd
-
 val tail_f : string -> cmd
-
 val echo : string -> cmd
-
 val cut' : ?complement:unit -> ?d:char -> int list -> cmd
-
 val cut : ?d:char (** defaults to a space *) -> int -> cmd
-
 val cp : string -> string -> cmd
-
 val cp_r : string -> string -> cmd
-
 val mv : string -> string -> cmd
-
 val pwd : cmd
 
 val sed :
@@ -215,10 +186,9 @@ val sed :
   cmd
 
 val tr : string -> string -> cmd
-
 val tr_d : string -> cmd
 
-(** {2 {b Misc } } *)
+(** {2 {b Misc}} *)
 
 val of_list : string list -> cmd
 (** [of_list] emulates a Feather.cmd, each item in the list becomes a line on
@@ -231,10 +201,10 @@ val devnull : string
 (** [devnull] is easier to type than "/dev/null" *)
 
 val fzf : ?cwd:string -> ?env:(string * string) list -> cmd -> string option
-(** [fzf] runs the command, and fuzzy finds the stdout.
-   Returns [None] if no item was chosen, [Some str] otherwise
+(** [fzf] runs the command, and fuzzy finds the stdout. Returns [None] if no
+    item was chosen, [Some str] otherwise
 
-   Note that [fzf] is a way to to run a [cmd] and does not in itself return a
-   [cmd]. *)
+    Note that [fzf] is a way to to run a [cmd] and does not in itself return a
+    [cmd]. *)
 
 val debug : bool ref


### PR DESCRIPTION
Another option for ocamformat config is to use the `conventional` profile.

This may be closer to the current state of the files at tip.

This is another data point related to #38 and an alternative for #40 

@charlesetc by the way something I was reminded of while looking at profiles, with this profile the additional option `wrap-comments=true` is supported which I have limited experience with but I think I'd find that convenient. I enabled it here for you to have a look, if you ended up preferring this style.

Thanks!