### PR TITLE
Fix inline test sending SIGVTALRM instead of SIGURG

### DIFF
--- a/src/feather.ml
+++ b/src/feather.ml
@@ -708,9 +708,7 @@ hi
         ./feather.ml |}]
 
     let%expect_test "waitpid should retry on EINTR" =
-      process "kill"
-        (List.map ~f:Int.to_string [ Stdlib.Sys.sigurg; Unix.getpid () ])
-      |> print;
+      process "kill" [ "-URG"; Int.to_string (Unix.getpid ()) ] |> print;
       [%expect ""]
 
     let%expect_test "redirection/collection" =


### PR DESCRIPTION
This test passed Sys.sigurg directly as a string argument to the kill command:

This is not the actual intention because [Sys.sigurg] is not a system signal number:

```sh
utop # Int.to_string Sys.sigurg ;;
- : string = "-26"
```

The kill command interprets 26 as a system signal number, which on Linux is SIGVTALRM, not SIGURG:

```sh
$ kill -L
...
23) SIGURG ... 26) SIGVTALRM
...
```

Use `kill -URG` to send the intended signal by name, which should be portable and avoid the issue.

#### Acknowledgement

- Crediting `Opus 4.6 with 1M context` which helped me track the source of the build failure.